### PR TITLE
Issue #50: content of request form overlaps with the sidebar

### DIFF
--- a/froide/account/forms.py
+++ b/froide/account/forms.py
@@ -16,18 +16,18 @@ class NewUserForm(forms.Form):
     first_name = forms.CharField(max_length=30,
             label=_('First name'),
             widget=forms.TextInput(attrs={'placeholder': _('First Name'),
-                'class': 'span5'}))
+                'class': 'input-medium'}))
     last_name = forms.CharField(max_length=30,
             label=_('Last name'),
             widget=forms.TextInput(attrs={'placeholder': _('Last Name'),
-                'class': 'span5'}))
+                'class': 'input-medium'}))
     address = forms.CharField(max_length=300,
             required=False,
             label=_('Mailing Address'),
             help_text=_('Your address will not be displayed publicly and is only needed in case a public body needs to send you paper.'),
             widget=forms.Textarea(attrs={
                 'rows': '3',
-                'class': 'span7',
+                'class': 'input-large',
                 'placeholder': _('Street, Post Code, City'),
             }))
     user_email = forms.EmailField(label=_('Email address'),

--- a/froide/account/templates/account/login.html
+++ b/froide/account/templates/account/login.html
@@ -46,9 +46,7 @@
   <form class="form-horizontal" method="post" action="{% url 'account-signup' %}">
     {% csrf_token %}
     {% if next %}<input type="hidden" name="next" value="{{ next }}"/>{% endif %}
-    <div class="row-fluid">
     {% form signup_form using "bootstrap/horizontal.html" %}
-    </div>
     <button type="submit" class="btn">{% blocktrans %}Sign Up{% endblocktrans %}</button>
   </form>
 </div>

--- a/froide/foirequest/templates/foirequest/request.html
+++ b/froide/foirequest/templates/foirequest/request.html
@@ -185,8 +185,8 @@
                   {{ user_form.first_name.errors }}
                   {{ user_form.last_name.errors }}
                   <p>
-                    {{ user_form.first_name }}
-                    {{ user_form.last_name }}
+                    <div class="inline">{{ user_form.first_name }}</div>
+                    <div class="inline">{{ user_form.last_name }}</div>
                   </p>
                 </div>
               {% endif %}


### PR DESCRIPTION
Hi @stefanw

I have looked into it - the fieldset has a padding and contains multiple fixed-sized bootstrap grids. This leads to the overlap with the similar request box on the right. As you can see on your image, the section above "Schritt 3" doesn't overlap because it doesn't contain a nested fixed-sized bootstrap grid.

My suggestion is to use the fluid grid system of bootstrap for nested grids (css class row-fluid instead of row). This won't lead to any sizing issues if you have an extra border or padding on the parent element.

I had to change some spanX class definitions in forms.py to keep the intended width of the input fields. Please review it, i have only checked the login and request page as an anonymous user.
