### PR TITLE
Fix law assignment (for jurisdiction & public body)

### DIFF
--- a/froide/foirequest/tests/factories.py
+++ b/froide/foirequest/tests/factories.py
@@ -278,7 +278,7 @@ def make_world():
         meta=True)
 
     for i in range(5):
-        pb_bund_1 = PublicBodyFactory.create(jurisdiction=bund, site=site, pk=(400 + i))
+        pb_bund_1 = PublicBodyFactory.create(jurisdiction=bund, site=site, pk=(1400 + i))
         pb_bund_1.tags.add(topic_1)
         pb_bund_1.laws.add(ifg_bund, uig_bund, meta_bund)
     for _ in range(5):
@@ -286,7 +286,7 @@ def make_world():
         pb_nrw_1.tags.add(topic_2)
         pb_nrw_1.laws.add(ifg_nrw, uig_nrw, meta_nrw)
     for i in range(5):
-        pb_fakejur_1 = PublicBodyFactory.create(jurisdiction=fakejur, site=site, pk=(500 + i))
+        pb_fakejur_1 = PublicBodyFactory.create(jurisdiction=fakejur, site=site, pk=(1500 + i))
         if i == 0:
             pb_fakejur_1.laws.add(ifg1_fakejur, ifg2_fakejur)
         elif i == 1:

--- a/froide/foirequest/tests/factories.py
+++ b/froide/foirequest/tests/factories.py
@@ -286,12 +286,12 @@ def make_world():
         pb_nrw_1.tags.add(topic_2)
         pb_nrw_1.laws.add(ifg_nrw, uig_nrw, meta_nrw)
     for i in range(5):
-        pb_fakejur_1 = PublicBodyFactory.create(jurisdiction=fakejur, site=site, pk=500+i)
-        if i==0:
+        pb_fakejur_1 = PublicBodyFactory.create(jurisdiction=fakejur, site=site, pk=(500 + i))
+        if i == 0:
             pb_fakejur_1.laws.add(ifg1_fakejur, ifg2_fakejur)
-        elif i==1:
-            pb_fakejur_1.laws.add(ifg1_fakejur) # UIG only, for whatever reason
-        elif i==2:
+        elif i == 1:
+            pb_fakejur_1.laws.add(ifg1_fakejur)  # UIG only, for whatever reason
+        elif i == 2:
             pb_fakejur_1.laws.add(ifg1_fakejur, ifg2_fakejur, meta_fakejur)
     req = FoiRequestFactory.create(site=site, user=user1, jurisdiction=bund,
         law=meta_bund, public_body=pb_bund_1)

--- a/froide/foirequest/tests/factories.py
+++ b/froide/foirequest/tests/factories.py
@@ -277,8 +277,8 @@ def make_world():
     meta_fakejur = FoiLawFactory.create(site=site, jurisdiction=fakejur, name='IFG-UIG fakefake',
         meta=True)
 
-    for _ in range(5):
-        pb_bund_1 = PublicBodyFactory.create(jurisdiction=bund, site=site)
+    for i in range(5):
+        pb_bund_1 = PublicBodyFactory.create(jurisdiction=bund, site=site, pk=(100 + i))
         pb_bund_1.tags.add(topic_1)
         pb_bund_1.laws.add(ifg_bund, uig_bund, meta_bund)
     for _ in range(5):

--- a/froide/foirequest/tests/factories.py
+++ b/froide/foirequest/tests/factories.py
@@ -278,7 +278,7 @@ def make_world():
         meta=True)
 
     for i in range(5):
-        pb_bund_1 = PublicBodyFactory.create(jurisdiction=bund, site=site, pk=(100 + i))
+        pb_bund_1 = PublicBodyFactory.create(jurisdiction=bund, site=site, pk=(400 + i))
         pb_bund_1.tags.add(topic_1)
         pb_bund_1.laws.add(ifg_bund, uig_bund, meta_bund)
     for _ in range(5):

--- a/froide/foirequest/tests/factories.py
+++ b/froide/foirequest/tests/factories.py
@@ -242,6 +242,7 @@ def make_world():
     UserFactory.create(is_staff=True, username='dummy_staff')
     bund = JurisdictionFactory.create(name='Bund')
     nrw = JurisdictionFactory.create(name='NRW')
+    fakejur = JurisdictionFactory.create(name='fakefake')
 
     topic_1 = PublicBodyTagFactory.create(is_topic=True)
     topic_2 = PublicBodyTagFactory.create(is_topic=True)
@@ -271,6 +272,11 @@ def make_world():
         meta=True)
     meta_nrw.combined.add(ifg_nrw, uig_nrw)
 
+    ifg1_fakejur = FoiLawFactory.create(site=site, jurisdiction=fakejur, priority=0, name='UIG fakefake')
+    ifg2_fakejur = FoiLawFactory.create(site=site, jurisdiction=fakejur, priority=100, name='IFG fakefake')
+    meta_fakejur = FoiLawFactory.create(site=site, jurisdiction=fakejur, name='IFG-UIG fakefake',
+        meta=True)
+
     for _ in range(5):
         pb_bund_1 = PublicBodyFactory.create(jurisdiction=bund, site=site)
         pb_bund_1.tags.add(topic_1)
@@ -279,6 +285,14 @@ def make_world():
         pb_nrw_1 = PublicBodyFactory.create(jurisdiction=nrw, site=site)
         pb_nrw_1.tags.add(topic_2)
         pb_nrw_1.laws.add(ifg_nrw, uig_nrw, meta_nrw)
+    for i in range(5):
+        pb_fakejur_1 = PublicBodyFactory.create(jurisdiction=fakejur, site=site, pk=500+i)
+        if i==0:
+            pb_fakejur_1.laws.add(ifg1_fakejur, ifg2_fakejur)
+        elif i==1:
+            pb_fakejur_1.laws.add(ifg1_fakejur) # UIG only, for whatever reason
+        elif i==2:
+            pb_fakejur_1.laws.add(ifg1_fakejur, ifg2_fakejur, meta_fakejur)
     req = FoiRequestFactory.create(site=site, user=user1, jurisdiction=bund,
         law=meta_bund, public_body=pb_bund_1)
     FoiMessageFactory.create(request=req, sender_user=user1,

--- a/froide/foirequest/tests/test_request.py
+++ b/froide/foirequest/tests/test_request.py
@@ -74,7 +74,7 @@ class RequestTest(TestCase):
     def test_public_body_new_user_request(self):
         self.client.logout()
         factories.UserFactory.create(email="dummy@example.com")
-        pb = PublicBody.objects.all()[0]
+        pb = PublicBody.objects.get(pk=100)
         post = {"subject": "Test-Subject With New User",
                 "body": "This is a test body with new user",
                 "first_name": "Stefan", "last_name": "Wehrmeyer",

--- a/froide/foirequest/tests/test_request.py
+++ b/froide/foirequest/tests/test_request.py
@@ -74,7 +74,7 @@ class RequestTest(TestCase):
     def test_public_body_new_user_request(self):
         self.client.logout()
         factories.UserFactory.create(email="dummy@example.com")
-        pb = PublicBody.objects.get(pk=400)
+        pb = PublicBody.objects.get(pk=1400)
         post = {"subject": "Test-Subject With New User",
                 "body": "This is a test body with new user",
                 "first_name": "Stefan", "last_name": "Wehrmeyer",

--- a/froide/foirequest/tests/test_request.py
+++ b/froide/foirequest/tests/test_request.py
@@ -74,7 +74,7 @@ class RequestTest(TestCase):
     def test_public_body_new_user_request(self):
         self.client.logout()
         factories.UserFactory.create(email="dummy@example.com")
-        pb = PublicBody.objects.get(pk=100)
+        pb = PublicBody.objects.get(pk=400)
         post = {"subject": "Test-Subject With New User",
                 "body": "This is a test body with new user",
                 "first_name": "Stefan", "last_name": "Wehrmeyer",

--- a/froide/publicbody/models.py
+++ b/froide/publicbody/models.py
@@ -109,20 +109,21 @@ class FoiLaw(models.Model):
         return u"%s (%s)" % (self.name, self.jurisdiction)
 
     @classmethod
-    def default_from_list(cls,lst):
-        return sorted(lst, key=lambda x:x.priority_score, reverse=True)[0]
+    def default_from_list(cls, lst):
+        return sorted(lst, key=lambda x: x.priority_score, reverse=True)[0]
 
     @classmethod
-    @property
     def global_default(cls):
         try:
-            return FoiLaw.objects.get(id=settings.FROIDE_CONFIG.get("default_law", 1))
+            return FoiLaw.objects.get(
+                    id=settings.FROIDE_CONFIG.get("default_law", 1)
+                   )
         except FoiLaw.DoesNotExist:
             return None
 
     @property
     def priority_score(self):
-        return self.priority+(1000 if self.meta else 0)
+        return self.priority + (1000 if self.meta else 0)
 
     def get_absolute_url(self):
         return reverse('publicbody-foilaw-show', kwargs={'slug': self.slug})
@@ -169,7 +170,6 @@ class FoiLaw(models.Model):
         if pb:
             return pb.default_law
         return cls.global_default()
-
 
     def as_dict(self):
         return {
@@ -317,7 +317,6 @@ class PublicBody(models.Model):
     serializable_fields = ('name', 'slug', 'request_note_html',
             'description', 'url', 'email', 'contact',
             'address', 'domain')
-
 
     def __str__(self):
         return u"%s (%s)" % (self.name, self.jurisdiction)

--- a/froide/publicbody/tests.py
+++ b/froide/publicbody/tests.py
@@ -19,7 +19,7 @@ class PublicBodyTest(TestCase):
     def test_web_page(self):
         response = self.client.get(reverse('publicbody-list'))
         self.assertEqual(response.status_code, 200)
-        pb = PublicBody.objects.all()[0]
+        pb = [x for x in PublicBody.objects.all() if x.tags.all()][0] # not all publicbodies have tags
         tag = pb.tags.all()[0]
         response = self.client.get(reverse('publicbody-list', kwargs={
             'topic': tag.slug
@@ -137,17 +137,16 @@ Public Body X 76,pb-76@76.example.com,bund,,,,http://example.com,,Ministry,Some 
         self.assertEqual(Jurisdiction.objects.get(name='NRW').default_law.name, 'IFG-UIG NRW')
 
         for pb in juris.publicbody_set.all():
-            j = pb.pk-500
+            j = pb.pk - 500
             deflaw = pb.default_law
             if j == 0:
                 self.assertEqual(deflaw.name, 'IFG fakefake')
             elif j == 1:
                 self.assertEqual(deflaw.name, 'UIG fakefake')
-            elif j==2:
+            elif j == 2:
                 self.assertEqual(deflaw.name, 'IFG-UIG fakefake')
             else:
                 self.assertEqual(deflaw.name, 'IFG-UIG fakefake')
-
 
         juris = Jurisdiction.objects.create(name='rofl')
         FoiLaw.objects.create(name='rofl testtest', meta=True, jurisdiction=juris)

--- a/froide/publicbody/tests.py
+++ b/froide/publicbody/tests.py
@@ -19,7 +19,7 @@ class PublicBodyTest(TestCase):
     def test_web_page(self):
         response = self.client.get(reverse('publicbody-list'))
         self.assertEqual(response.status_code, 200)
-        pb = [x for x in PublicBody.objects.all() if x.tags.all()][0] # not all publicbodies have tags
+        pb = [x for x in PublicBody.objects.all() if x.tags.all()][0]  # not all publicbodies have tags
         tag = pb.tags.all()[0]
         response = self.client.get(reverse('publicbody-list', kwargs={
             'topic': tag.slug

--- a/froide/publicbody/tests.py
+++ b/froide/publicbody/tests.py
@@ -137,7 +137,7 @@ Public Body X 76,pb-76@76.example.com,bund,,,,http://example.com,,Ministry,Some 
         self.assertEqual(Jurisdiction.objects.get(name='NRW').default_law.name, 'IFG-UIG NRW')
 
         for pb in juris.publicbody_set.all():
-            j = pb.pk - 500
+            j = pb.pk - 1500
             deflaw = pb.default_law
             if j == 0:
                 self.assertEqual(deflaw.name, 'IFG fakefake')

--- a/froide/publicbody/tests.py
+++ b/froide/publicbody/tests.py
@@ -130,6 +130,30 @@ Public Body X 76,pb-76@76.example.com,bund,,,,http://example.com,,Ministry,Some 
                 kwargs={'jurisdiction': juris.slug}))
         self.assertEqual(response.status_code, 200)
 
+    def test_law_assignment(self):
+        juris = Jurisdiction.objects.get(name='fakefake')
+
+        self.assertEqual(juris.default_law.name, 'IFG-UIG fakefake')
+        self.assertEqual(Jurisdiction.objects.get(name='NRW').default_law.name, 'IFG-UIG NRW')
+
+        for pb in juris.publicbody_set.all():
+            j = pb.pk-500
+            deflaw = pb.default_law
+            if j == 0:
+                self.assertEqual(deflaw.name, 'IFG fakefake')
+            elif j == 1:
+                self.assertEqual(deflaw.name, 'UIG fakefake')
+            elif j==2:
+                self.assertEqual(deflaw.name, 'IFG-UIG fakefake')
+            else:
+                self.assertEqual(deflaw.name, 'IFG-UIG fakefake')
+
+
+        juris = Jurisdiction.objects.create(name='rofl')
+        FoiLaw.objects.create(name='rofl testtest', meta=True, jurisdiction=juris)
+        FoiLaw.objects.create(name='rofl test2', meta=False, priority=1500, jurisdiction=juris)
+        self.assertEqual(juris.default_law.name, 'rofl test2')
+
 
 class ApiTest(TestCase):
     def setUp(self):

--- a/froide/settings.py
+++ b/froide/settings.py
@@ -452,7 +452,7 @@ class Test(Base):
     MESSAGE_STORAGE = 'django.contrib.messages.storage.cookie.CookieStorage'
     CACHES = values.CacheURLValue('locmem://')
 
-    TEST_SELENIUM_DRIVER = values.Value('chrome')
+    TEST_SELENIUM_DRIVER = values.Value('phantomjs')
 
     USE_X_ACCEL_REDIRECT = True
 

--- a/froide/settings.py
+++ b/froide/settings.py
@@ -452,7 +452,7 @@ class Test(Base):
     MESSAGE_STORAGE = 'django.contrib.messages.storage.cookie.CookieStorage'
     CACHES = values.CacheURLValue('locmem://')
 
-    TEST_SELENIUM_DRIVER = values.Value('phantomjs')
+    TEST_SELENIUM_DRIVER = values.Value('chrome')
 
     USE_X_ACCEL_REDIRECT = True
 

--- a/froide/tests/live/test_request.py
+++ b/froide/tests/live/test_request.py
@@ -7,10 +7,12 @@ from django.contrib.auth import get_user_model
 from django.core import mail
 
 from selenium.webdriver.support.wait import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 from froide.foirequest.tests import factories
 from froide.foirequest.models import FoiRequest
 from froide.publicbody.models import PublicBody
+
 
 User = get_user_model()
 
@@ -325,7 +327,12 @@ class TestMakingRequest(LiveServerTestCase):
             self.scrollTo(klass='target-small')
             WebDriverWait(self.selenium, 10).until(
                 lambda driver: self.selenium.find_element_by_xpath(login_link).is_displayed())
-            self.selenium.find_element_by_xpath(login_link).click()
+
+            login_link_el = self.selenium.find_element_by_xpath(login_link);
+
+            WebDriverWait(self.selenium, 10).until(
+                lambda driver: EC.element_to_be_clickable(login_link_el))
+            login_link_el.click()
 
         popup_handle = [wh for wh in self.selenium.window_handles if wh != main_window_handle][0]
         self.selenium.switch_to_window(popup_handle)

--- a/froide/tests/live/test_request.py
+++ b/froide/tests/live/test_request.py
@@ -329,7 +329,6 @@ class TestMakingRequest(LiveServerTestCase):
                 lambda driver: self.selenium.find_element_by_xpath(login_link).is_displayed())
 
             login_link_el = self.selenium.find_element_by_xpath(login_link)
-
             WebDriverWait(self.selenium, 10).until(
                 lambda driver: EC.element_to_be_clickable(login_link_el))
             login_link_el.click()

--- a/froide/tests/live/test_request.py
+++ b/froide/tests/live/test_request.py
@@ -328,7 +328,7 @@ class TestMakingRequest(LiveServerTestCase):
             WebDriverWait(self.selenium, 10).until(
                 lambda driver: self.selenium.find_element_by_xpath(login_link).is_displayed())
 
-            login_link_el = self.selenium.find_element_by_xpath(login_link);
+            login_link_el = self.selenium.find_element_by_xpath(login_link)
 
             WebDriverWait(self.selenium, 10).until(
                 lambda driver: EC.element_to_be_clickable(login_link_el))


### PR DESCRIPTION
fix Law/Jurisdiction / PublicBody assignment assignment issue.

By-Default, select law by priority; Meta adds 1000 to priority implicitly.
By-Default, select law by Jurisdiction. FoiLaw.laws becomes an override opportunity

Currently considering creating a script that compares the previous logic with the new one, and allows people to remove unnecessary overrides in publicbodies. Thoughts?
