### PR TITLE
Add current time to timestamp of manually uploaded messages

### DIFF
--- a/froide/foirequest/forms.py
+++ b/froide/foirequest/forms.py
@@ -461,7 +461,8 @@ class PostalBaseForm(AttachmentSaverMixin, forms.Form):
             is_postal=True,
         )
         # TODO: Check if timezone support is correct
-        date = datetime.datetime.combine(self.cleaned_data['date'], datetime.time())
+        date = datetime.datetime.combine(self.cleaned_data['date'],
+                                         datetime.datetime.now().time())
         message.timestamp = timezone.get_current_timezone().localize(date)
         message.subject = self.cleaned_data.get('subject', '')
         message.subject_redacted = message.redact_subject()[:250]


### PR DESCRIPTION
This solves #213 by adding the current time to the date of the upload form.