### PR TITLE
Update download buttons in sidebar.html

### DIFF
--- a/froide/foirequest/templates/foirequest/snippets/sidebar.html
+++ b/froide/foirequest/templates/foirequest/snippets/sidebar.html
@@ -107,13 +107,13 @@
  {% if object|can_read_foirequest_authenticated:request %}
     <li class="nav-header">{% trans "Download" %}</li>
     <li class="nav-item">
-      <a class="btn btn-light" href="{% url 'foirequest-download' slug=object.slug %}">
+      <a class="btn btn-light w-100 mb-1" href="{% url 'foirequest-download' slug=object.slug %}">
         <i class="fa fa-download"></i>
         {% trans "Download request as ZIP-file" %}
       </a>
     </li>
     <li class="nav-item">
-      <a class="btn btn-light" href="{% url 'foirequest-pdf' slug=object.slug %}">
+      <a class="btn btn-light w-100" href="{% url 'foirequest-pdf' slug=object.slug %}">
         <i class="fa fa-file-pdf-o"></i>
         {% trans "Download request as PDF" %}
       </a>


### PR DESCRIPTION
Currently, the download buttons in the sidebar look like this:
![buttons1](https://user-images.githubusercontent.com/13052748/55410995-1db57580-5565-11e9-81fb-1a565bbf8698.png)

In order for it to look better, I added these changes, which stretch the buttons to 100 % width and add a small margin between the two buttons:
![buttons21](https://user-images.githubusercontent.com/13052748/55411004-2017cf80-5565-11e9-81d8-9da944e4d775.png)

But the translations need to be changed as well: "Download request as ZIP-file" is too long. I propose "Download as ZIP-file" and in German "Download als ZIP"; as well as "Download as PDF". Then the strings look more symmetric and still express the same information. But I don't know how to change these translations, so feel free to help.

