### PR TITLE
Use correct undo/redo icons in PDF redact

### DIFF
--- a/frontend/javascript/components/redaction/redaction.vue
+++ b/frontend/javascript/components/redaction/redaction.vue
@@ -32,11 +32,11 @@
       <div v-if="ready" class="btn-toolbar col-lg-12">
         <div class="btn-group mr-1">
           <button class="btn btn-light" @click="undo" :disabled="!canUndo" :title="i18n.undo">
-            <i class="fa fa-step-backward"></i>
+            <i class="fa fa-undo"></i>
           </button>
           <button class="btn btn-light" @click="redo" :disabled="!canRedo"
             data-toggle="tooltip" data-placement="top" :title="i18n.redo">
-            <i class="fa fa-step-forward"></i>
+            <i class="fa fa-repeat"></i>
           </button>
         </div>
 


### PR DESCRIPTION
Before:

![grafik](https://user-images.githubusercontent.com/1222377/56240085-d534a680-6092-11e9-8a48-47b93c9dc084.png)


After:

![grafik](https://user-images.githubusercontent.com/1222377/56240041-bcc48c00-6092-11e9-9bb7-5eb1c77f6c76.png)
