### PR TITLE
Fix EscalationMessageForm

### DIFF
--- a/froide/foirequest/forms/message.py
+++ b/froide/foirequest/forms/message.py
@@ -425,7 +425,6 @@ class EscalationMessageForm(forms.Form):
         subject = re.sub(r'\s*\[#%s\]\s*$' % self.foirequest.pk, '', subject)
         subject = '%s [#%s]' % (subject, self.foirequest.pk)
 
-        subject = '%s [#%s]' % (subject, self.foirequest.pk)
         subject_redacted = redact_subject(subject, user=user)
 
         plaintext = construct_message_body(


### PR DESCRIPTION
Appending the Foi request number twice in escalation messages lead to a wrong subject in mediation emails. Removing the code duplication should fix this issue.

This commit fixes #368.