### PR TITLE
allow user messages to receive guidance

### DIFF
--- a/froide/guide/utils.py
+++ b/froide/guide/utils.py
@@ -140,9 +140,6 @@ class GuidanceApplicator:
 
 
 def run_guidance(message, active_only=True, notify=False):
-    if not message.is_response:
-        return
-
     applicator = GuidanceApplicator(message, active_only=active_only)
     result = applicator.run()
 


### PR DESCRIPTION
With Topf Secret, many requests don't get a response at all, like this one: https://fragdenstaat.de/anfrage/kontrollbericht-zu-wolke-berlin/

This change allows us to help users get a response by adding guidance to their messages.