### PR TITLE
Fix class name

### DIFF
--- a/froide/foirequest/management/commands/fetch_foi_mail.py
+++ b/froide/foirequest/management/commands/fetch_foi_mail.py
@@ -2,7 +2,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.utils import translation
 from django.conf import settings
 
-from froide.foirequest.email import fetch_and_process
+from froide.foirequest.foi_mail import fetch_and_process
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
FOI mail class name changed in 3de57145e7f5c32aa3ab8db9785b2a7cfdcb16ce.