### PR TITLE
Fix long request text fade-out

### DIFF
--- a/frontend/styles/components/alpha/header.scss
+++ b/frontend/styles/components/alpha/header.scss
@@ -59,7 +59,7 @@
   left: 0;
   right: 0;
   padding-top: 80px;
-  background-image: linear-gradient(to bottom, transparent, $gray-100);
+  background-image: linear-gradient(to bottom, rgba($gray-100, 0), $gray-100);
 }
 
 .info-box {


### PR DESCRIPTION
This PR fixes the text fade-out on the request page (alpha) for Safari to not fade to gray, but the background color instead. Firefox should be unaffected by this patch and still fades correctly.

<img width="500" alt="screenshot" src="https://user-images.githubusercontent.com/6250567/103307904-71424500-4a11-11eb-88fa-e44264a33e7a.png">