### PR TITLE
Switch to better FontAwesome icons for revert redaction

### DIFF
--- a/frontend/javascript/components/redaction/redaction.vue
+++ b/frontend/javascript/components/redaction/redaction.vue
@@ -90,7 +90,7 @@
             :title="i18n.undo"
             @click="undo"
           >
-            <i class="fas fa-share fa-flip-horizontal" />
+            <i class="fa fa-share fa-flip-horizontal" />
           </button>
           <button
             class="btn btn-light"
@@ -100,7 +100,7 @@
             :title="i18n.redo"
             @click="redo"
           >
-            <i class="fas fa-share" />
+            <i class="fa fa-share" />
           </button>
         </div>
 

--- a/frontend/javascript/components/redaction/redaction.vue
+++ b/frontend/javascript/components/redaction/redaction.vue
@@ -90,7 +90,7 @@
             :title="i18n.undo"
             @click="undo"
           >
-            <i class="fa fa-step-backward" />
+            <i class="fas fa-share fa-flip-horizontal" />
           </button>
           <button
             class="btn btn-light"
@@ -100,7 +100,7 @@
             :title="i18n.redo"
             @click="redo"
           >
-            <i class="fa fa-step-forward" />
+            <i class="fas fa-share" />
           </button>
         </div>
 


### PR DESCRIPTION
Fixes https://github.com/okfde/froide/issues/439 by applying the code [from here](https://jsfiddle.net/tagliala/zvkwmf1L/3/).

Note **this is completely untested**, I'm just doing the code changes to bring that forward, as it is a very annoying thing for me and I personally like this solution. :)
Especially it may need to be checked, whether the used FontAwesome version is up-to-date for this syntax…