### PR TITLE
Allow TESSERACT_LANGUAGE to be overridden in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ python3 -m venv froide-env
 source froide-env/bin/activate
 
 # Install dev dependencies
-pip install requirements-test.txt
+pip install -r requirements-test.txt
 
 # Install git pre-commit hook
 pre-commit install

--- a/froide/foirequest/tasks.py
+++ b/froide/foirequest/tasks.py
@@ -233,8 +233,11 @@ def ocr_pdf_task(att_id, target_id, can_approve=True):
 
     try:
         pdf_bytes = run_ocr(
-            attachment.file.path, language=settings.TESSERACT_LANGUAGE if hasattr(
-                settings, 'TESSERACT_LANGUAGE') else settings.LANGUAGE_CODE, timeout=180
+            attachment.file.path,
+            language=settings.TESSERACT_LANGUAGE
+            if settings.TESSERACT_LANGUAGE
+            else settings.LANGUAGE_CODE,
+            timeout=180,
         )
     except SoftTimeLimitExceeded:
         pdf_bytes = None
@@ -302,7 +305,11 @@ def redact_attachment_task(att_id, target_id, instructions):
 
     try:
         pdf_bytes = run_ocr(
-            target.file.path, language=settings.TESSERACT_LANGUAGE if hasattr(settings, 'TESSERACT_LANGUAGE') else settings.LANGUAGE_CODE, timeout=60 * 4
+            target.file.path,
+            language=settings.TESSERACT_LANGUAGE
+            if settings.TESSERACT_LANGUAGE
+            else settings.LANGUAGE_CODE,
+            timeout=60 * 4,
         )
     except SoftTimeLimitExceeded:
         pdf_bytes = None

--- a/froide/foirequest/tasks.py
+++ b/froide/foirequest/tasks.py
@@ -233,7 +233,8 @@ def ocr_pdf_task(att_id, target_id, can_approve=True):
 
     try:
         pdf_bytes = run_ocr(
-            attachment.file.path, language=settings.LANGUAGE_CODE, timeout=180
+            attachment.file.path, language=settings.TESSERACT_LANGUAGE if hasattr(
+                settings, 'TESSERACT_LANGUAGE') else settings.LANGUAGE_CODE, timeout=180
         )
     except SoftTimeLimitExceeded:
         pdf_bytes = None
@@ -301,7 +302,7 @@ def redact_attachment_task(att_id, target_id, instructions):
 
     try:
         pdf_bytes = run_ocr(
-            target.file.path, language=settings.LANGUAGE_CODE, timeout=60 * 4
+            target.file.path, language=settings.TESSERACT_LANGUAGE if hasattr(settings, 'TESSERACT_LANGUAGE') else settings.LANGUAGE_CODE, timeout=60 * 4
         )
     except SoftTimeLimitExceeded:
         pdf_bytes = None

--- a/froide/settings.py
+++ b/froide/settings.py
@@ -528,6 +528,8 @@ class Base(Configuration):
     )
 
     TESSERACT_DATA_PATH = values.Value("/usr/local/share/tessdata")
+    # allow override of settings.LANGUAGE_CODE for Tesseract
+    TESSERACT_LANGUAGE = None
 
     # ###### Email ##############
 


### PR DESCRIPTION
At FragDenStaat.at, we're using the language code de-at to allow us to use the German translations while overwriting some messages. This throws off Tesseract / django-filer. I'd like to propose allowing a seperate setting for the tesseract language code.