### PR TITLE
Add postfix logparsing as a seperate task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,7 @@ htmlcov:
 
 messagesde:
 	django-admin makemessages -l de --ignore public --ignore froide-env --ignore node_modules --ignore htmlcov --add-location file
+
+requirements: requirements.in requirements-test.in
+	pip-compile requirements.in
+	pip-compile requirements-test.in

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,8 +10,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/froide/bounce/tasks.py
+++ b/froide/bounce/tasks.py
@@ -2,7 +2,7 @@ from django.conf import settings
 
 from froide.celery import app as celery_app
 
-from .utils import check_bounce_mails, check_unsubscribe_mails
+from .utils import check_bounce_mails, check_unsubscribe_mails, check_delivery_from_log
 
 HANDLE_BOUNCES = settings.FROIDE_CONFIG["bounce_enabled"]
 HANDLE_UNSUBSCRIBE = settings.FROIDE_CONFIG["unsubscribe_enabled"]
@@ -14,6 +14,9 @@ def check_bounces():
         return
     check_bounce_mails()
 
+@celery_app.task(name='froide.bounce.tasks.check_mail_log', expires=60*60)
+def check_mail_log():
+    check_delivery_from_log()
 
 @celery_app.task(name="froide.bounce.tasks.check_unsubscribe", expires=60 * 60)
 def check_unsubscribe():

--- a/froide/bounce/tasks.py
+++ b/froide/bounce/tasks.py
@@ -2,7 +2,7 @@ from django.conf import settings
 
 from froide.celery import app as celery_app
 
-from .utils import check_bounce_mails, check_unsubscribe_mails, check_delivery_from_log
+from .utils import check_bounce_mails, check_unsubscribe_mails
 
 HANDLE_BOUNCES = settings.FROIDE_CONFIG["bounce_enabled"]
 HANDLE_UNSUBSCRIBE = settings.FROIDE_CONFIG["unsubscribe_enabled"]
@@ -14,9 +14,6 @@ def check_bounces():
         return
     check_bounce_mails()
 
-@celery_app.task(name='froide.bounce.tasks.check_mail_log', expires=60*60)
-def check_mail_log():
-    check_delivery_from_log()
 
 @celery_app.task(name="froide.bounce.tasks.check_unsubscribe", expires=60 * 60)
 def check_unsubscribe():

--- a/froide/bounce/utils.py
+++ b/froide/bounce/utils.py
@@ -4,12 +4,16 @@ https://en.wikipedia.org/wiki/Variable_envelope_return_path
 
 """
 import base64
+from contextlib import closing
 import datetime
 import time
 from contextlib import closing
 from email.utils import parseaddr
 from io import BytesIO
+import re
+import time
 from urllib.parse import quote
+from pygtail import Pygtail
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -31,6 +35,8 @@ from froide.helper.email_utils import (
 
 from .models import Bounce
 from .signals import email_bounced, email_unsubscribed, user_email_bounced
+from froide.foirequest.models.message import FoiMessage, DeliveryStatus, MessageKind
+from froide.foirequest.delivery import get_delivery_reporter
 
 BOUNCE_FORMAT = settings.FROIDE_CONFIG["bounce_format"]
 UNSUBSCRIBE_FORMAT = settings.FROIDE_CONFIG["unsubscribe_format"]
@@ -150,11 +156,11 @@ def get_recipient_address_from_unsubscribe(unsub_email):
 
 
 def get_original_email_from_signed(
-    signed_email, email_format=BOUNCE_FORMAT, max_age=MAX_BOUNCE_AGE
+        signed_email, email_format=BOUNCE_FORMAT, max_age=MAX_BOUNCE_AGE
 ):
     head, tail = email_format.split("{token}")
     # Cut off head and tail of bounce formatting
-    token = signed_email[len(head) : -len(tail)]
+    token = signed_email[len(head): -len(tail)]
     parts = token.split(SEP_REPL)
     signature = SIGN_SEP.join(parts[:2])
 
@@ -176,11 +182,11 @@ def get_original_email_from_signed(
 
 def check_bounce_mails():
     with get_mail_client(
-        settings.BOUNCE_EMAIL_HOST_IMAP,
-        settings.BOUNCE_EMAIL_PORT_IMAP,
-        settings.BOUNCE_EMAIL_ACCOUNT_NAME,
-        settings.BOUNCE_EMAIL_ACCOUNT_PASSWORD,
-        ssl=settings.BOUNCE_EMAIL_USE_SSL,
+            settings.BOUNCE_EMAIL_HOST_IMAP,
+            settings.BOUNCE_EMAIL_PORT_IMAP,
+            settings.BOUNCE_EMAIL_ACCOUNT_NAME,
+            settings.BOUNCE_EMAIL_ACCOUNT_PASSWORD,
+            ssl=settings.BOUNCE_EMAIL_USE_SSL,
     ) as client:
         for _mail_uid, rfc_data in get_unread_mails(client, flag=False):
             process_bounce_mail(rfc_data)
@@ -188,11 +194,11 @@ def check_bounce_mails():
 
 def check_unsubscribe_mails():
     with get_mail_client(
-        settings.UNSUBSCRIBE_EMAIL_HOST_IMAP,
-        settings.UNSUBSCRIBE_EMAIL_PORT_IMAP,
-        settings.UNSUBSCRIBE_EMAIL_ACCOUNT_NAME,
-        settings.UNSUBSCRIBE_EMAIL_ACCOUNT_PASSWORD,
-        ssl=settings.UNSUBSCRIBE_EMAIL_USE_SSL,
+            settings.UNSUBSCRIBE_EMAIL_HOST_IMAP,
+            settings.UNSUBSCRIBE_EMAIL_PORT_IMAP,
+            settings.UNSUBSCRIBE_EMAIL_ACCOUNT_NAME,
+            settings.UNSUBSCRIBE_EMAIL_ACCOUNT_PASSWORD,
+            ssl=settings.UNSUBSCRIBE_EMAIL_USE_SSL,
     ) as client:
         for _mail_uid, rfc_data in get_unread_mails(client, flag=False):
             process_unsubscribe_mail(rfc_data)
@@ -282,12 +288,12 @@ def check_deactivation_condition(bounce):
     """
 
     if check_bounce_status(
-        bounce.bounces, "hard", HARD_BOUNCE_PERIOD, HARD_BOUNCE_COUNT
+            bounce.bounces, "hard", HARD_BOUNCE_PERIOD, HARD_BOUNCE_COUNT
     ):
         return True
 
     if check_bounce_status(
-        bounce.bounces, "soft", SOFT_BOUNCE_PERIOD, SOFT_BOUNCE_COUNT
+            bounce.bounces, "soft", SOFT_BOUNCE_PERIOD, SOFT_BOUNCE_COUNT
     ):
         return True
 
@@ -324,3 +330,173 @@ def handle_smtp_error(exc):
             continue
         raise exc
     return True
+
+
+def check_delivery_from_log():
+    """
+    check and update the delivery status of FOI-Messages
+
+    1. query model for all FOI-messages that have an update-able delivery state
+    2. collect new postfix-log entries
+    3. match msg-ids from postfix log with queries FOI-messages
+    4. update FOI-messages accordingly
+    """
+    POSTFIX_LOG_PATH = "/var/log/mail.log"
+    PYGTAIL_OFFSET_PATH = "./mail_log.offset"
+    FINAL_STATES = DeliveryStatus.FINAL_STATUS
+    RELEVANT_FIELDS = {"message-id", "from", "to", "status"}
+
+    # query model
+    messages = (
+        FoiMessage.objects.exclude(deliverystatus__status__in=FINAL_STATES)
+            .filter(kind=MessageKind.EMAIL)
+            .exclude(is_response=True)
+            .exclude(sender_email__isnull=True)
+            .exclude(recipient_email__isnull=True)
+    )
+
+    message_lookup = {message.make_message_id(): message for message in messages}
+
+    # collect log
+    pygtail = Pygtail(POSTFIX_LOG_PATH, offset_file=PYGTAIL_OFFSET_PATH)
+
+    postfix_messages = dict()
+    # will contain mappings from postfix queue_id to message information
+
+    for line in pygtail:
+        date, queue_id, fields = prepare_line(line)
+        if queue_id is None:
+            continue
+
+        if queue_id in postfix_messages and check_obsolete_queue_id(
+                message_info=postfix_messages[queue_id],
+                fields=fields,
+                message_lookup=message_lookup,
+        ):
+            del postfix_messages[queue_id]
+            continue
+
+        if queue_id not in postfix_messages:
+            postfix_messages[queue_id] = dict(log=list())
+
+        postfix_messages[queue_id]["log"].append(line)
+
+        new_entries = prepare_key_value_pairs_from_fields(
+            fields=fields, relevant_fields=RELEVANT_FIELDS
+        )
+        postfix_messages[queue_id].update(new_entries)
+
+    for parsed_info in postfix_messages:
+        if (
+                "status" in parsed_info
+                and "log" in parsed_info
+                and parsed_info.get("message-id") in message_lookup
+        ):
+            generate_delivery_status(parsed_info)
+
+
+def prepare_line(line: str):
+    """this consumes one log line (e.g. from pygtail)
+    it returns a  3 tuple with a date-string, queue-id and list of key-value pairs
+    or (None, None, None) if the line does not have information for delivery state
+    """
+    if "postfix" not in line:
+        # DKIM line
+        return None, None, None
+    date, info = line.split("mail", maxsplit=1)
+    contents = info.rsplit(":")
+    # general postfix log format uses ":" as delimiter
+    # lines consist of date, host and process info, optional queue id followed by information on the logged event
+
+    if len(contents) == 2:
+        # no queue id in current line -> no send-mail event
+        return None, None, None
+
+    queue_id = contents[1]
+
+    if "TLS" in queue_id:
+        # log lines for TLS handshakes do not contain queue ids
+        return None, None, None
+
+    fields = contents[-1].split(",")
+    # queue-events are in comma-seprated lists of key=value-pairs
+
+    return date, queue_id, fields
+
+
+def check_obsolete_queue_id(message_info: dict, fields: list, message_lookup: dict):
+    """
+    this checks for a given prepared log line if it is the last one for a given queue-id
+    if so it generates the deliveryStatus if necessary
+
+    this will return true if the given fields indicate that this is the last log line for given queue-id
+
+    deliveryStatus is generated if:
+        (a) the message has not already entered a final state and
+        (b) there has been status information for the message in log for the message
+    """
+    if (
+            len(fields) == 1
+            and "removed" in fields[0]
+            and "status" in message_info
+            and "log" in message_info
+            and message_info.get("message-id") in message_lookup.keys()
+    ):
+        generate_delivery_status(
+            message_info=message_info, message_lookup=message_lookup
+        )
+        return True
+    else:
+        return False
+
+
+def prepare_key_value_pairs_from_fields(fields: list, relevant_fields: set):
+    """
+    this takes all the fields from a log line as prepared by prepare_line and processes all the key-value pairs in it
+
+    this returns a dict with all the key-value mapping extracted from the log line
+    """
+    kv_map = dict()
+
+    for field in fields:
+        if "=" in field:
+            name, value = field.split("=", maxsplit=1)
+            # Under certain circumstances values can contain "=", so we split only once
+        else:
+            name = field
+            value = field
+
+        name = name.strip()
+        if "message-id" not in name:
+            value = value.replace("<", "").replace(">", "")
+            # everything resampling a mail address comes enclosed in < > in mail.log
+            # however mail-addresses in froide are stored without those, while the message-id is stored with.
+
+        value = value.strip()
+
+        if len(relevant_fields) != 0 and name in relevant_fields:
+            # only collect what's needed
+            kv_map[name] = value
+
+        return kv_map
+
+
+def generate_delivery_status(
+        message_info: dict,
+        message_lookup: dict,
+        last_update=timezone.now(),
+):
+    assert "log" in message_info
+    assert "status" in message_info
+
+    message_id = message_info.get("message-id")
+    message = message_lookup.get(message_id)
+    if message:
+        ds, created = DeliveryStatus.objects.update_or_create(
+            message=message,
+            defaults=dict(
+                log="".join(message_info.get("log")),
+                status=message_info.get("status"),
+                last_update=last_update,
+            ),
+        )

--- a/froide/bounce/utils.py
+++ b/froide/bounce/utils.py
@@ -4,16 +4,12 @@ https://en.wikipedia.org/wiki/Variable_envelope_return_path
 
 """
 import base64
-from contextlib import closing
 import datetime
 import time
 from contextlib import closing
 from email.utils import parseaddr
 from io import BytesIO
-import re
-import time
 from urllib.parse import quote
-from pygtail import Pygtail
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -35,8 +31,6 @@ from froide.helper.email_utils import (
 
 from .models import Bounce
 from .signals import email_bounced, email_unsubscribed, user_email_bounced
-from froide.foirequest.models.message import FoiMessage, DeliveryStatus, MessageKind
-from froide.foirequest.delivery import get_delivery_reporter
 
 BOUNCE_FORMAT = settings.FROIDE_CONFIG["bounce_format"]
 UNSUBSCRIBE_FORMAT = settings.FROIDE_CONFIG["unsubscribe_format"]
@@ -156,11 +150,11 @@ def get_recipient_address_from_unsubscribe(unsub_email):
 
 
 def get_original_email_from_signed(
-        signed_email, email_format=BOUNCE_FORMAT, max_age=MAX_BOUNCE_AGE
+    signed_email, email_format=BOUNCE_FORMAT, max_age=MAX_BOUNCE_AGE
 ):
     head, tail = email_format.split("{token}")
     # Cut off head and tail of bounce formatting
-    token = signed_email[len(head): -len(tail)]
+    token = signed_email[len(head) : -len(tail)]
     parts = token.split(SEP_REPL)
     signature = SIGN_SEP.join(parts[:2])
 
@@ -182,11 +176,11 @@ def get_original_email_from_signed(
 
 def check_bounce_mails():
     with get_mail_client(
-            settings.BOUNCE_EMAIL_HOST_IMAP,
-            settings.BOUNCE_EMAIL_PORT_IMAP,
-            settings.BOUNCE_EMAIL_ACCOUNT_NAME,
-            settings.BOUNCE_EMAIL_ACCOUNT_PASSWORD,
-            ssl=settings.BOUNCE_EMAIL_USE_SSL,
+        settings.BOUNCE_EMAIL_HOST_IMAP,
+        settings.BOUNCE_EMAIL_PORT_IMAP,
+        settings.BOUNCE_EMAIL_ACCOUNT_NAME,
+        settings.BOUNCE_EMAIL_ACCOUNT_PASSWORD,
+        ssl=settings.BOUNCE_EMAIL_USE_SSL,
     ) as client:
         for _mail_uid, rfc_data in get_unread_mails(client, flag=False):
             process_bounce_mail(rfc_data)
@@ -194,11 +188,11 @@ def check_bounce_mails():
 
 def check_unsubscribe_mails():
     with get_mail_client(
-            settings.UNSUBSCRIBE_EMAIL_HOST_IMAP,
-            settings.UNSUBSCRIBE_EMAIL_PORT_IMAP,
-            settings.UNSUBSCRIBE_EMAIL_ACCOUNT_NAME,
-            settings.UNSUBSCRIBE_EMAIL_ACCOUNT_PASSWORD,
-            ssl=settings.UNSUBSCRIBE_EMAIL_USE_SSL,
+        settings.UNSUBSCRIBE_EMAIL_HOST_IMAP,
+        settings.UNSUBSCRIBE_EMAIL_PORT_IMAP,
+        settings.UNSUBSCRIBE_EMAIL_ACCOUNT_NAME,
+        settings.UNSUBSCRIBE_EMAIL_ACCOUNT_PASSWORD,
+        ssl=settings.UNSUBSCRIBE_EMAIL_USE_SSL,
     ) as client:
         for _mail_uid, rfc_data in get_unread_mails(client, flag=False):
             process_unsubscribe_mail(rfc_data)
@@ -288,12 +282,12 @@ def check_deactivation_condition(bounce):
     """
 
     if check_bounce_status(
-            bounce.bounces, "hard", HARD_BOUNCE_PERIOD, HARD_BOUNCE_COUNT
+        bounce.bounces, "hard", HARD_BOUNCE_PERIOD, HARD_BOUNCE_COUNT
     ):
         return True
 
     if check_bounce_status(
-            bounce.bounces, "soft", SOFT_BOUNCE_PERIOD, SOFT_BOUNCE_COUNT
+        bounce.bounces, "soft", SOFT_BOUNCE_PERIOD, SOFT_BOUNCE_COUNT
     ):
         return True
 
@@ -330,173 +324,3 @@ def handle_smtp_error(exc):
             continue
         raise exc
     return True
-
-
-def check_delivery_from_log():
-    """
-    check and update the delivery status of FOI-Messages
-
-    1. query model for all FOI-messages that have an update-able delivery state
-    2. collect new postfix-log entries
-    3. match msg-ids from postfix log with queries FOI-messages
-    4. update FOI-messages accordingly
-    """
-    POSTFIX_LOG_PATH = "/var/log/mail.log"
-    PYGTAIL_OFFSET_PATH = "./mail_log.offset"
-    FINAL_STATES = DeliveryStatus.FINAL_STATUS
-    RELEVANT_FIELDS = {"message-id", "from", "to", "status"}
-
-    # query model
-    messages = (
-        FoiMessage.objects.exclude(deliverystatus__status__in=FINAL_STATES)
-            .filter(kind=MessageKind.EMAIL)
-            .exclude(is_response=True)
-            .exclude(sender_email__isnull=True)
-            .exclude(recipient_email__isnull=True)
-    )
-
-    message_lookup = {message.make_message_id(): message for message in messages}
-
-    # collect log
-    pygtail = Pygtail(POSTFIX_LOG_PATH, offset_file=PYGTAIL_OFFSET_PATH)
-
-    postfix_messages = dict()
-    # will contain mappings from postfix queue_id to message information
-
-    for line in pygtail:
-        date, queue_id, fields = prepare_line(line)
-        if queue_id is None:
-            continue
-
-        if queue_id in postfix_messages and check_obsolete_queue_id(
-                message_info=postfix_messages[queue_id],
-                fields=fields,
-                message_lookup=message_lookup,
-        ):
-            del postfix_messages[queue_id]
-            continue
-
-        if queue_id not in postfix_messages:
-            postfix_messages[queue_id] = dict(log=list())
-
-        postfix_messages[queue_id]["log"].append(line)
-
-        new_entries = prepare_key_value_pairs_from_fields(
-            fields=fields, relevant_fields=RELEVANT_FIELDS
-        )
-        postfix_messages[queue_id].update(new_entries)
-
-    for parsed_info in postfix_messages:
-        if (
-                "status" in parsed_info
-                and "log" in parsed_info
-                and parsed_info.get("message-id") in message_lookup
-        ):
-            generate_delivery_status(parsed_info)
-
-
-def prepare_line(line: str):
-    """this consumes one log line (e.g. from pygtail)
-    it returns a  3 tuple with a date-string, queue-id and list of key-value pairs
-    or (None, None, None) if the line does not have information for delivery state
-    """
-    if "postfix" not in line:
-        # DKIM line
-        return None, None, None
-    date, info = line.split("mail", maxsplit=1)
-    contents = info.rsplit(":")
-    # general postfix log format uses ":" as delimiter
-    # lines consist of date, host and process info, optional queue id followed by information on the logged event
-
-    if len(contents) == 2:
-        # no queue id in current line -> no send-mail event
-        return None, None, None
-
-    queue_id = contents[1]
-
-    if "TLS" in queue_id:
-        # log lines for TLS handshakes do not contain queue ids
-        return None, None, None
-
-    fields = contents[-1].split(",")
-    # queue-events are in comma-seprated lists of key=value-pairs
-
-    return date, queue_id, fields
-
-
-def check_obsolete_queue_id(message_info: dict, fields: list, message_lookup: dict):
-    """
-    this checks for a given prepared log line if it is the last one for a given queue-id
-    if so it generates the deliveryStatus if necessary
-
-    this will return true if the given fields indicate that this is the last log line for given queue-id
-
-    deliveryStatus is generated if:
-        (a) the message has not already entered a final state and
-        (b) there has been status information for the message in log for the message
-    """
-    if (
-            len(fields) == 1
-            and "removed" in fields[0]
-            and "status" in message_info
-            and "log" in message_info
-            and message_info.get("message-id") in message_lookup.keys()
-    ):
-        generate_delivery_status(
-            message_info=message_info, message_lookup=message_lookup
-        )
-        return True
-    else:
-        return False
-
-
-def prepare_key_value_pairs_from_fields(fields: list, relevant_fields: set):
-    """
-    this takes all the fields from a log line as prepared by prepare_line and processes all the key-value pairs in it
-
-    this returns a dict with all the key-value mapping extracted from the log line
-    """
-    kv_map = dict()
-
-    for field in fields:
-        if "=" in field:
-            name, value = field.split("=", maxsplit=1)
-            # Under certain circumstances values can contain "=", so we split only once
-        else:
-            name = field
-            value = field
-
-        name = name.strip()
-        if "message-id" not in name:
-            value = value.replace("<", "").replace(">", "")
-            # everything resampling a mail address comes enclosed in < > in mail.log
-            # however mail-addresses in froide are stored without those, while the message-id is stored with.
-
-        value = value.strip()
-
-        if len(relevant_fields) != 0 and name in relevant_fields:
-            # only collect what's needed
-            kv_map[name] = value
-
-        return kv_map
-
-
-def generate_delivery_status(
-        message_info: dict,
-        message_lookup: dict,
-        last_update=timezone.now(),
-):
-    assert "log" in message_info
-    assert "status" in message_info
-
-    message_id = message_info.get("message-id")
-    message = message_lookup.get(message_id)
-    if message:
-        ds, created = DeliveryStatus.objects.update_or_create(
-            message=message,
-            defaults=dict(
-                log="".join(message_info.get("log")),
-                status=message_info.get("status"),
-                last_update=last_update,
-            ),
-        )

--- a/froide/foirequest/delivery.py
+++ b/froide/foirequest/delivery.py
@@ -13,6 +13,14 @@ from froide.helper.utils import get_module_attr_from_dotted_path
 
 
 def get_delivery_report(sender, recipient, timestamp, extended=False):
+    reporter = get_delivery_reporter()
+    if reporter:
+        return reporter.find(sender, recipient, timestamp, extended=extended)
+    else:
+        return
+
+
+def get_delivery_reporter():
     from django.conf import settings
 
     reporter_path = settings.FROIDE_CONFIG.get("delivery_reporter", None)
@@ -20,9 +28,8 @@ def get_delivery_report(sender, recipient, timestamp, extended=False):
         return
 
     reporter_klass = get_module_attr_from_dotted_path(reporter_path)
-
     reporter = reporter_klass(time_zone=settings.TIME_ZONE)
-    return reporter.find(sender, recipient, timestamp, extended=extended)
+    return reporter
 
 
 DeliveryReport = namedtuple(
@@ -83,14 +90,17 @@ class PostfixDeliveryReporter(object):
             if result:
                 return result
 
-    def search_log(self, fp, sender, recipient, timestamp):
+    def search_log(self, fp, sender, recipient, timestamp, real_file=True):
         sender_re = re.compile(self.SENDER_RE.format(sender=sender))
         mail_ids = set()
         for line in fp:
             match = sender_re.search(line)
             if match:
                 mail_ids.add(match.group("mail_id"))
-        fp.seek(0)
+
+        if real_file:
+            fp.seek(0)
+
         mail_id_res = [
             re.compile(self.ALL_RE.format(mail_id=mail_id)) for mail_id in mail_ids
         ]

--- a/froide/helper/email_log_parsing.py
+++ b/froide/helper/email_log_parsing.py
@@ -1,0 +1,181 @@
+import collections
+import re
+from collections import defaultdict, namedtuple
+from typing import Iterable, Optional
+
+from pygtail import Pygtail
+
+from .signals import email_left_queue
+
+PostfixLogLine = namedtuple("PostfixLogLine", ["date", "queue_id", "data"])
+
+
+class PostfixLogfileParser(collections.abc.Iterator):
+    """
+    Parses a mail log for postfix delivery information.
+
+    This iterator yields delivery notices for messages in the mail log.
+    """
+
+    DEFAULT_RELEVANT_FIELDS = {"message-id", "from", "to", "status", "removed"}
+    QUEUE_ID_REGEX = r"(?P<queue_id>[0-9A-F]{6,}|[0-9a-zA-Z]{12,})"
+    TIMESTAMP_RE = r"(?P<timestamp>\w{3}\s+\d+\s+\d+:\d+:\d+)"
+    USER_RE = r"(?P<user>[^ ]+)"
+    PROCESS_RE = r"(?P<process>[^:]+)"
+    FIELDS_RE = r"(?P<fields>.*)"
+    LINE_RE = rf"^{TIMESTAMP_RE} {USER_RE} {PROCESS_RE}: {QUEUE_ID_REGEX}: {FIELDS_RE}$"
+
+    def __init__(
+        self, logfile_reader: Iterable[str], relevant_fields: Optional[Iterable] = None
+    ):
+        self.logfile_reader = logfile_reader
+        self.relevant_fields = (
+            relevant_fields
+            if relevant_fields is not None
+            else self.DEFAULT_RELEVANT_FIELDS
+        )
+        self._msg_log = defaultdict(lambda: {"log": [], "data": {}})
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        for line in self.logfile_reader:
+            parsed_line = self._parse_line(line)
+            if parsed_line is None:
+                continue
+
+            self._msg_log[parsed_line.queue_id]["log"].append(line)
+            self._msg_log[parsed_line.queue_id]["data"].update(parsed_line.data)
+
+            if self._is_completed_message(self._msg_log[parsed_line.queue_id]):
+                msg = self._msg_log[parsed_line.queue_id]
+                del self._msg_log[parsed_line.queue_id]
+                if not self._msg_log:
+                    self.on_empty_log()
+                return msg
+
+        raise StopIteration
+
+    def on_empty_log(self):
+        pass
+
+    def _is_completed_message(self, msg):
+        return "removed" in msg["data"]
+
+    def _parse_line(self, line: str) -> Optional[PostfixLogLine]:
+        """Parse a single postfix logline
+
+        Lines consist of date, host and process info, optional queue id followed by information on the logged event
+        Lines should look like:
+
+        ```
+        Jan 1 01:02:03 mail postfix/something[1234566]: ABCDEF1234: field=value
+        ```
+
+        Args:
+            line (str): The log line to be parsed
+
+        Returns:
+            Optional[PostfixLogLine]: If the logline was parsed successfullt, a PostfixLogLine namedtuple is returned. If it could not be parsed, None is returned
+        """
+
+        match = re.match(self.LINE_RE, line)
+        if not match:
+            return
+        line_data = match.groupdict()
+
+        # We only care for postfix lines
+        if "postfix" not in line_data["process"]:
+            return None
+
+        data = self._parse_fields(line_data["fields"].split(","), self.relevant_fields)
+        return PostfixLogLine(line_data["timestamp"], line_data["queue_id"], data)
+
+    @staticmethod
+    def _parse_fields(fields: list, relevant_fields: Optional[Iterable] = None) -> dict:
+        """Parse a list of postfix fields into a dictionary
+
+        Args:
+            fields (list): A list of fields from a postfix log message
+            relevant_fields (Optional[Iterable], optional): If not None, only these keys will be stored in the dictionary. Other fields will be ignored . Defaults to None.
+
+        Returns:
+            dict: A dictionary containing the key-value pairs from the given fields
+        """
+        kv_map = dict()
+
+        for field in fields:
+            if "=" in field:
+                name, value = field.split("=", maxsplit=1)
+                # Under certain circumstances values can contain "=", so we split only once
+            else:
+                name = field
+                value = ""
+
+            name = name.strip()
+            # Ignore this field if relevant fields were given and this is not one of them
+            if relevant_fields is not None and name not in relevant_fields:
+                continue
+
+            # anything resembling a mail address comes enclosed in < > in mail.log
+            # however mail-addresses in froide are stored without those, while the message-id is stored with.
+            if name != "message-id":
+                value = value.replace("<", "").replace(">", "")
+
+            # We only care for the first word of the status ()
+            if name == "status":
+                value = value.strip().split(" ")[0]
+
+            kv_map[name] = value.strip()
+
+        return kv_map
+
+
+class PygtailPostfixLogfileParser(PostfixLogfileParser):
+    """A logfile parser that keeps track of its position in the logfile using pygtail.
+
+    It tries to ignore parts of the log that were already fully processed.
+    However it can only ignore parts at the beginning of the log where all mails
+    where queue ids seen in the logfile until then left the queue.
+    This means that if a message bounces for a longer time, the log position
+    cannot be updated until this message is either delivered successfully or is
+    deleted from the queue.
+    Until then parts of the log will be processed again and again and the messages
+    is this part will be returned by the iterator on every invocation.
+    """
+
+    DEFAULT_POSTFIX_LOG_PATH = "/var/log/mail.log"
+    DEFAULT_PYGTAIL_OFFSET_PATH = "./mail_log.offset"
+
+    def __init__(
+        self, log_path: Optional[str] = None, offset_path: Optional[str] = None
+    ):
+        if log_path is None:
+            log_path = self.DEFAULT_POSTFIX_LOG_PATH
+
+        if offset_path is None:
+            offset_path = self.DEFAULT_PYGTAIL_OFFSET_PATH
+
+        self.logfile_reader = Pygtail(
+            log_path, offset_file=offset_path, full_lines=True, save_on_end=False
+        )
+        super().__init__(self.logfile_reader)
+
+    def on_empty_log(self):
+        self.logfile_reader.update_offset_file()
+
+
+def check_delivery_from_log(
+    log_path: Optional[str] = None, offset_path: Optional[str] = None
+):
+    parser = PygtailPostfixLogfileParser(log_path, offset_path)
+    for message in parser:
+        email_left_queue.send(
+            sender=__name__,
+            to=message["data"].get("to"),
+            from_address=message["data"].get("from"),
+            message_id=message["data"].get("message-id"),
+            status=message["data"].get("status"),
+            log=message["log"],
+        )

--- a/froide/helper/management/commands/parse_mail_log.py
+++ b/froide/helper/management/commands/parse_mail_log.py
@@ -1,0 +1,16 @@
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.utils import translation
+
+from froide.helper.email_log_parsing import check_delivery_from_log
+
+
+class Command(BaseCommand):
+    help = "Processes mail logs for deliveries"
+
+    def add_arguments(self, parser):
+        parser.add_argument("log_path", default=None)
+
+    def handle(self, *args, **options):
+        translation.activate(settings.LANGUAGE_CODE)
+        check_delivery_from_log(options["log_path"])

--- a/froide/helper/signals.py
+++ b/froide/helper/signals.py
@@ -1,0 +1,3 @@
+from django.dispatch import Signal
+
+email_left_queue = Signal()  # args: ['to', 'from', 'message_id', 'status', 'log']

--- a/froide/helper/tasks.py
+++ b/froide/helper/tasks.py
@@ -8,6 +8,7 @@ from elasticsearch.exceptions import ConnectionTimeout
 
 from froide.celery import app as celery_app
 from froide.foirequest.models.request import FoiRequest
+from froide.helper.email_log_parsing import check_delivery_from_log
 
 logger = logging.getLogger(__name__)
 
@@ -52,3 +53,8 @@ def search_instance_delete(model_name: str, pk: Optional[int]) -> None:
     instance.pk = pk
     instance.id = pk
     registry.delete(instance, raise_on_error=False)
+
+
+@celery_app.task(expires=60 * 60)
+def check_mail_log():
+    check_delivery_from_log()

--- a/froide/helper/tasks.py
+++ b/froide/helper/tasks.py
@@ -55,6 +55,6 @@ def search_instance_delete(model_name: str, pk: Optional[int]) -> None:
     registry.delete(instance, raise_on_error=False)
 
 
-@celery_app.task(expires=60 * 60)
+@celery_app.task(expires=60)
 def check_mail_log():
     check_delivery_from_log()

--- a/froide/helper/tests/test_email_log_parsing.py
+++ b/froide/helper/tests/test_email_log_parsing.py
@@ -1,0 +1,207 @@
+import io
+import os.path
+import tempfile
+
+from django.test import TestCase
+
+from ..email_log_parsing import (
+    PostfixLogfileParser,
+    PostfixLogLine,
+    check_delivery_from_log,
+)
+from ..signals import email_left_queue
+
+TEST_DATA_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "testdata"))
+
+
+def p(path):
+    return os.path.join(TEST_DATA_ROOT, path)
+
+
+class MaillogParseTest(TestCase):
+    DEMO_FIELDS = [
+        " to=<poststelle@zitis.bund.de>",
+        " relay=mx1.bund.de[77.87.224.131]:25",
+        " delay=0.54",
+        " delays=0.09/0.01/0.28/0.16",
+        " dsn=2.0.0",
+        " status=sent (250 2.0.0 Ok: queued as QUEUEUEUEUEU)",
+    ]
+
+    MAIL_1_ID = "<foirequest/123123@example.com>"
+    MAIL_1_LOG = [
+        "Jan 1 01:02:04 mail postfix/smtpd[1234567]: 163CB3EE5E7F: client=localhost.localdomain[127.0.0.1], sasl_method=PLAIN, sasl_username=examplemail@example.com\n",
+        "Jan 1 01:02:04 mail postfix/cleanup[2345678]: 163CB3EE5E7F: message-id=<foirequest/123123@example.com>\n",
+        "Jan 1 01:02:05 mail postfix/qmgr[2345678]: 163CB3EE5E7F: from=<bounce+asdadasd=+132kl12j31n12d1190+a.foo=example.com@example.com>, size=12321, nrcpt=1 (queue active)\n",
+        "Jan 1 01:02:05 mail postfix/smtp[2345678]: 163CB3EE5E7F: to=<a.foo@example.com>, relay=example.com[123.456.789.123]:25, delay=0.67, delays=0.1/0.37/0.13/0.07, dsn=2.0.0, status=sent (250 Requested mail action okay, completed: id=aaaaa-bbbbb-ccccc-ddddd\n",
+        "Jan 1 01:02:05 mail postfix/qmgr[2345678]: 163CB3EE5E7F: removed\n",
+    ]
+    MAIL_2_ID = "<foimsg.1324123.12312312312312.1231@mail.example.com>"
+    MAIL_2_LOG = [
+        "Jan 1 01:02:04 mail postfix/smtpd[2345678]: 065AB16D682C: client=localhost.localdomain[127.0.0.1], sasl_method=PLAIN, sasl_username=examplemail@example.com\n",
+        "Jan 1 01:02:04 mail postfix/cleanup[2345678]: 065AB16D682C: message-id=<foimsg.1324123.12312312312312.1231@mail.example.com>\n",
+        "Jan 1 01:02:04 mail postfix/qmgr[2345678]: 065AB16D682C: from=<a.foo.sadasd1231as@example.com>, size=5608, nrcpt=1 (queue active)\n",
+        "Jan 1 01:02:05 mail postfix/smtp[2345678]: 065AB16D682C: to=<b.doe@example.org>, relay=example.org[234.456.321.123]:25, delay=5.2, delays=0.09/0.02/0.14/4.9, dsn=2.0.0, status=sent (250 2.0.0 Ok: queued as ABCDEF)\n",
+        "Jan 1 01:02:05 mail postfix/qmgr[2345678]: 065AB16D682C: removed\n",
+    ]
+    MAIL_2_DATA = {
+        "message-id": "<foimsg.1324123.12312312312312.1231@mail.example.com>",
+        "from": "a.foo.sadasd1231as@example.com",
+        "to": "b.doe@example.org",
+        "status": "sent",
+        "removed": "",
+    }
+
+    def test_parse_field_minimal(self):
+        self.assertEqual(
+            PostfixLogfileParser._parse_fields(self.DEMO_FIELDS),
+            {
+                "to": "poststelle@zitis.bund.de",
+                "relay": "mx1.bund.de[77.87.224.131]:25",
+                "delay": "0.54",
+                "delays": "0.09/0.01/0.28/0.16",
+                "dsn": "2.0.0",
+                "status": "sent",
+            },
+        )
+
+    def test_parse_fields_limit(self):
+        self.assertEqual(
+            PostfixLogfileParser._parse_fields(self.DEMO_FIELDS, ["to", "status"]),
+            {
+                "to": "poststelle@zitis.bund.de",
+                "status": "sent",
+            },
+        )
+
+        self.assertEqual(
+            PostfixLogfileParser._parse_fields(self.DEMO_FIELDS, {"to", "status"}),
+            {
+                "to": "poststelle@zitis.bund.de",
+                "status": "sent",
+            },
+        )
+
+    def test_parse_without_value(self):
+        self.assertEqual(
+            PostfixLogfileParser._parse_fields([" removed"]),
+            {
+                "removed": "",
+            },
+        )
+
+    def test_parse_empty_file(self):
+        parser = PostfixLogfileParser(io.StringIO(""))
+        self.assertEqual(next(parser, None), None)
+
+    def test_parse_line(self):
+        parser = PostfixLogfileParser(io.StringIO(""), relevant_fields={"field"})
+        self.assertEqual(
+            parser._parse_line(
+                "Jan 1 01:02:03 mail postfix/something[1234566]: ABCDEF1234: field=value"
+            ),
+            PostfixLogLine("Jan 1 01:02:03", "ABCDEF1234", {"field": "value"}),
+        )
+
+        self.assertEqual(
+            parser._parse_line(
+                "Jan 1 01:02:03 mail postfix/something[1234566]: ABCDEF1234: field=value, field2"
+            ),
+            PostfixLogLine("Jan 1 01:02:03", "ABCDEF1234", {"field": "value"}),
+        )
+
+    def test_parse_file(self):
+        parser = PostfixLogfileParser(open(p("maillog_001.txt")))
+        msg1 = next(parser)
+        self.assertEqual(msg1["data"]["message-id"], self.MAIL_1_ID)
+        self.assertEqual(len(msg1["log"]), 5)
+
+        self.assertEqual(len(parser._msg_log), 1)
+
+        msg2 = next(parser)
+        self.assertEqual(
+            msg2["data"],
+            self.MAIL_2_DATA,
+        )
+        self.assertEqual(
+            msg2["log"],
+            self.MAIL_2_LOG,
+        )
+        self.assertEqual(next(parser, None), None)
+
+        self.assertEqual(len(parser._msg_log), 0)
+
+    def test_parse_file_with_partial_log(self):
+        parser = PostfixLogfileParser(open(p("maillog_002.txt")))
+        self.assertEqual(next(parser, None), None)
+        self.assertEqual(len(parser._msg_log), 1)
+
+    def test_email_signal(self):
+        invocations = []
+
+        def callback(**kwargs):
+            invocations.append(kwargs)
+
+        email_left_queue.connect(callback)
+        self.assertEqual(len(invocations), 0)
+        with tempfile.TemporaryDirectory() as dir:
+            check_delivery_from_log(p("maillog_001.txt"), str(dir + "/mail_log.offset"))
+        self.assertEqual(len(invocations), 2)
+        self.assertEqual(invocations[0]["message_id"], self.MAIL_1_ID)
+        self.assertEqual(invocations[1]["message_id"], self.MAIL_2_ID)
+        self.assertEqual(
+            invocations[0]["log"],
+            self.MAIL_1_LOG,
+        )
+        self.assertEqual(
+            invocations[1]["log"],
+            self.MAIL_2_LOG,
+        )
+
+    def test_pygtail_log_append(self):
+        invocations = []
+
+        def callback(**kwargs):
+            invocations.append(kwargs)
+
+        email_left_queue.connect(callback)
+        self.assertEqual(len(invocations), 0)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logfile_path = str(tmpdir + "/mail_log")
+            offset_file_path = str(tmpdir + "/mail_log.offset")
+            with open(logfile_path, "w") as logfile:
+                check_delivery_from_log(logfile_path, offset_file_path)
+                self.assertEqual(len(invocations), 0)
+                with open(p("maillog_003.txt")) as fixture:
+                    logfile.write(fixture.read())
+                    logfile.flush()
+                check_delivery_from_log(logfile_path, offset_file_path)
+                self.assertEqual(len(invocations), 1)
+
+                with open(p("maillog_004.txt")) as fixture:
+                    logfile.write(fixture.read())
+                    logfile.flush()
+                check_delivery_from_log(logfile_path, offset_file_path)
+                self.assertEqual(len(invocations), 2)
+
+        self.assertEqual(invocations[0]["message_id"], self.MAIL_2_ID)
+        self.assertEqual(invocations[1]["message_id"], self.MAIL_1_ID)
+        self.assertEqual(
+            invocations[0]["log"],
+            self.MAIL_2_LOG,
+        )
+
+        self.assertEqual(invocations[1]["log"], self.MAIL_1_LOG)
+
+    def test_on_empty_log(self):
+        invocation_count = [0]
+
+        class LogParser(PostfixLogfileParser):
+            def on_empty_log(_):
+                invocation_count[0] += 1
+
+        parser = LogParser(open(p("maillog_001.txt")))
+        for _ in parser:
+            pass
+        self.assertEqual(invocation_count[0], 1)

--- a/froide/helper/tests/test_misc.py
+++ b/froide/helper/tests/test_misc.py
@@ -4,12 +4,12 @@ from datetime import datetime, timedelta
 from django.test import TestCase
 from django.test.utils import override_settings
 
-from .csv_utils import dict_to_csv_stream
-from .date_utils import calc_easter, calculate_month_range_de
-from .email_sending import mail_registry
-from .storage import make_unique_filename
-from .text_diff import mark_differences
-from .text_utils import remove_closing, replace_email_name, split_text_by_separator
+from ..csv_utils import dict_to_csv_stream
+from ..date_utils import calc_easter, calculate_month_range_de
+from ..email_sending import mail_registry
+from ..storage import make_unique_filename
+from ..text_diff import mark_differences
+from ..text_utils import remove_closing, replace_email_name, split_text_by_separator
 
 
 def rec(x):

--- a/froide/helper/tests/testdata/maillog_001.txt
+++ b/froide/helper/tests/testdata/maillog_001.txt
@@ -1,0 +1,22 @@
+Jan 1 01:02:03 mail postfix/smtpd[1234567]: connect from localhost.localdomain[127.0.0.1]
+Jan 1 01:02:03 mail opendmarc[2345678]: ignoring connection from localhost.localdomain
+Jan 1 01:02:03 mail postfix/smtpd[1234567]: Anonymous TLS connection established from localhost.localdomain[127.0.0.1]: TLSv1.3 with cipher TLS_AES_256_GCM_SHA384 (256/256 bits) key-exchange ECDHE (P-384) server-signature RSA-PSS (2048 bits) server-dig
+est SHA256
+Jan 1 01:02:04 mail postfix/smtpd[2345678]: 065AB16D682C: client=localhost.localdomain[127.0.0.1], sasl_method=PLAIN, sasl_username=examplemail@example.com
+Jan 1 01:02:04 mail postfix/cleanup[2345678]: 065AB16D682C: message-id=<foimsg.1324123.12312312312312.1231@mail.example.com>
+Jan 1 01:02:04 mail opendkim[2345678]: 065AB16D682C: DKIM-Signature field added (s=mail, d=example.com)
+Jan 1 01:02:04 mail postfix/qmgr[2345678]: 065AB16D682C: from=<a.foo.sadasd1231as@example.com>, size=5608, nrcpt=1 (queue active)
+Jan 1 01:02:04 mail postfix/smtpd[2345678]: disconnect from localhost.localdomain[127.0.0.1] ehlo=2 starttls=1 auth=1 mail=1 rcpt=1 data=1 quit=1 commands=8
+Jan 1 01:02:04 mail postfix/smtpd[1234567]: 163CB3EE5E7F: client=localhost.localdomain[127.0.0.1], sasl_method=PLAIN, sasl_username=examplemail@example.com
+Jan 1 01:02:04 mail postfix/cleanup[2345678]: 163CB3EE5E7F: message-id=<foirequest/123123@example.com>
+Jan 1 01:02:04 mail opendkim[2345678]: 163CB3EE5E7F: DKIM-Signature field added (s=mail, d=example.com)
+Jan 1 01:02:05 mail postfix/qmgr[2345678]: 163CB3EE5E7F: from=<bounce+asdadasd=+132kl12j31n12d1190+a.foo=example.com@example.com>, size=12321, nrcpt=1 (queue active)
+Jan 1 01:02:05 mail postfix/smtpd[1234567]: disconnect from localhost.localdomain[127.0.0.1] ehlo=2 starttls=1 auth=1 mail=1 rcpt=1 data=1 quit=1 commands=8
+Jan 1 01:02:05 mail postfix/smtp[2345678]: 163CB3EE5E7F: to=<a.foo@example.com>, relay=example.com[123.456.789.123]:25, delay=0.67, delays=0.1/0.37/0.13/0.07, dsn=2.0.0, status=sent (250 Requested mail action okay, completed: id=aaaaa-bbbbb-ccccc-ddddd
+)
+Jan 1 01:02:05 mail postfix/qmgr[2345678]: 163CB3EE5E7F: removed
+Jan 1 01:02:05 mail postfix/smtp[2345678]: 065AB16D682C: to=<b.doe@example.org>, relay=example.org[234.456.321.123]:25, delay=5.2, delays=0.09/0.02/0.14/4.9, dsn=2.0.0, status=sent (250 2.0.0 Ok: queued as ABCDEF)
+Jan 1 01:02:05 mail postfix/qmgr[2345678]: 065AB16D682C: removed
+Jan 1 01:02:05 mail postfix/anvil[2345678]: statistics: max connection rate 1/60s for (smtp:123.456.789.123) at Apr  9 23:53:41
+Jan 1 01:02:05 mail postfix/anvil[2345678]: statistics: max connection count 1 for (smtp:123.456.789.123) at Apr  9 23:53:41
+Jan 1 01:02:05 mail postfix/anvil[2345678]: statistics: max cache size 4 at Jan 1 00:01:03

--- a/froide/helper/tests/testdata/maillog_002.txt
+++ b/froide/helper/tests/testdata/maillog_002.txt
@@ -1,0 +1,5 @@
+Jan 1 01:02:03 mail postfix/smtpd[1234567]: connect from localhost.localdomain[127.0.0.1]
+Jan 1 01:02:04 mail postfix/cleanup[2345678]: 065AB16D682C: message-id=<foimsg.1324123.12312312312312.1231@mail.example.com>
+Jan 1 01:02:05 mail postfix/anvil[2345678]: statistics: max connection rate 1/60s for (smtp:123.456.789.123) at Apr  9 23:53:41
+Jan 1 01:02:05 mail postfix/anvil[2345678]: statistics: max connection count 1 for (smtp:123.456.789.123) at Apr  9 23:53:41
+Jan 1 01:02:05 mail postfix/anvil[2345678]: statistics: max cache size 4 at Jan 1 00:01:03

--- a/froide/helper/tests/testdata/maillog_003.txt
+++ b/froide/helper/tests/testdata/maillog_003.txt
@@ -1,0 +1,6 @@
+Jan 1 01:02:04 mail postfix/smtpd[2345678]: 065AB16D682C: client=localhost.localdomain[127.0.0.1], sasl_method=PLAIN, sasl_username=examplemail@example.com
+Jan 1 01:02:04 mail postfix/cleanup[2345678]: 065AB16D682C: message-id=<foimsg.1324123.12312312312312.1231@mail.example.com>
+Jan 1 01:02:04 mail opendkim[2345678]: 065AB16D682C: DKIM-Signature field added (s=mail, d=example.com)
+Jan 1 01:02:04 mail postfix/qmgr[2345678]: 065AB16D682C: from=<a.foo.sadasd1231as@example.com>, size=5608, nrcpt=1 (queue active)
+Jan 1 01:02:05 mail postfix/smtp[2345678]: 065AB16D682C: to=<b.doe@example.org>, relay=example.org[234.456.321.123]:25, delay=5.2, delays=0.09/0.02/0.14/4.9, dsn=2.0.0, status=sent (250 2.0.0 Ok: queued as ABCDEF)
+Jan 1 01:02:05 mail postfix/qmgr[2345678]: 065AB16D682C: removed

--- a/froide/helper/tests/testdata/maillog_004.txt
+++ b/froide/helper/tests/testdata/maillog_004.txt
@@ -1,0 +1,7 @@
+Jan 1 01:02:04 mail postfix/smtpd[1234567]: 163CB3EE5E7F: client=localhost.localdomain[127.0.0.1], sasl_method=PLAIN, sasl_username=examplemail@example.com
+Jan 1 01:02:04 mail postfix/cleanup[2345678]: 163CB3EE5E7F: message-id=<foirequest/123123@example.com>
+Jan 1 01:02:04 mail opendkim[2345678]: 163CB3EE5E7F: DKIM-Signature field added (s=mail, d=example.com)
+Jan 1 01:02:05 mail postfix/qmgr[2345678]: 163CB3EE5E7F: from=<bounce+asdadasd=+132kl12j31n12d1190+a.foo=example.com@example.com>, size=12321, nrcpt=1 (queue active)
+Jan 1 01:02:05 mail postfix/smtp[2345678]: 163CB3EE5E7F: to=<a.foo@example.com>, relay=example.com[123.456.789.123]:25, delay=0.67, delays=0.1/0.37/0.13/0.07, dsn=2.0.0, status=sent (250 Requested mail action okay, completed: id=aaaaa-bbbbb-ccccc-ddddd
+)
+Jan 1 01:02:05 mail postfix/qmgr[2345678]: 163CB3EE5E7F: removed

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -359,6 +359,8 @@ pyflakes==2.3.1
     # via
     #   -r requirements-test.in
     #   flake8
+pygtail==0.12.0
+    # via -r requirements.in
 pyisemail==1.3.2
     # via -r requirements.in
 pyopenssl==20.0.1

--- a/requirements.in
+++ b/requirements.in
@@ -5,8 +5,8 @@ channels
 coreapi
 dj-database-url
 django-cache-url
-django-celery-email
 django-celery-beat
+django-celery-email
 django-configurations
 django-contrib-comments
 django-crossdomainmedia
@@ -25,8 +25,8 @@ Django>=3.2,<3.3
 djangorestframework
 djangorestframework-csv
 djangorestframework-jsonp
-elasticsearch<8.0.0,>=7.0.0
 elasticsearch-dsl>=7.0.0<8.0.0
+elasticsearch<8.0.0,>=7.0.0
 geoip2
 icalendar
 lxml>=4.6.5
@@ -35,6 +35,7 @@ numpy>=1.21
 phonenumbers
 Pillow>=9.0.0
 psycopg2-binary
+pygtail>=0.12.0
 pyisemail
 pypdf2
 python-magic

--- a/requirements.txt
+++ b/requirements.txt
@@ -278,6 +278,8 @@ pyasn1-modules==0.2.8
     # via service-identity
 pycparser==2.20
     # via cffi
+pygtail==0.12.0
+    # via -r requirements.in
 pyisemail==1.3.2
     # via -r requirements.in
 pyopenssl==20.0.1


### PR DESCRIPTION
This continues @xenein‌s work in #455 and closes #454 

This adds a new [regex-based postfix log parser](https://github.com/okfde/froide/blob/66ac22f77d9142e1962a99cc0878aa3461c58f59/froide/helper/email_log_parsing.py#L13) which sends a [`froide.helper.signals.email_left_queue`](https://github.com/okfde/froide/blob/66ac22f77d9142e1962a99cc0878aa3461c58f59/froide/helper/email_log_parsing.py#L174) signal for each message which was removed from the postfix queue (mostly because they are delivered), which is then used to [update the message status](https://github.com/okfde/froide/blob/66ac22f77d9142e1962a99cc0878aa3461c58f59/froide/foirequest/signals.py#L464) 

Since the postfix parser is no longer specific to foi messages, I moved the code to `froide.helper`.