### PR TITLE
Add project actions to execute on many requests

### DIFF
--- a/froide/foirequest/auth.py
+++ b/froide/foirequest/auth.py
@@ -17,6 +17,7 @@ from froide.helper.auth import (
     can_write_object,
     check_permission,
     get_read_queryset,
+    get_write_queryset,
     has_authenticated_access,
 )
 
@@ -32,6 +33,17 @@ def get_read_foirequest_queryset(request: HttpRequest, queryset=None):
         has_team=True,
         public_q=Q(visibility=FoiRequest.VISIBILITY.VISIBLE_TO_PUBLIC),
         scope="read:request",
+    )
+
+
+def get_write_foirequest_queryset(request: HttpRequest, queryset=None):
+    if queryset is None:
+        queryset = FoiRequest.objects.all()
+    return get_write_queryset(
+        queryset,
+        request,
+        has_team=True,
+        scope="write:request",
     )
 
 

--- a/froide/foirequest/forms/__init__.py
+++ b/froide/foirequest/forms/__init__.py
@@ -16,6 +16,7 @@ from .message import (
 from .postal import PostalUploadForm
 from .project import (
     AssignProjectForm,
+    FoiRequestBulkForm,
     MakeProjectPublicForm,
     PublishRequestsForm,
     SendMessageProjectForm,
@@ -53,6 +54,7 @@ __all__ = [
     "RedactMessageForm",
     "PublicBodyUploader",
     "PostalUploadForm",
+    "FoiRequestBulkForm",
     "MakeProjectPublicForm",
     "PublishRequestsForm",
     "ApplyModerationForm",

--- a/froide/foirequest/forms/__init__.py
+++ b/froide/foirequest/forms/__init__.py
@@ -14,7 +14,12 @@ from .message import (
     get_send_message_form,
 )
 from .postal import PostalUploadForm
-from .project import AssignProjectForm, MakeProjectPublicForm
+from .project import (
+    AssignProjectForm,
+    MakeProjectPublicForm,
+    PublishRequestsForm,
+    SendMessageProjectForm,
+)
 from .request import (
     ApplyModerationForm,
     ConcreteLawForm,
@@ -49,6 +54,8 @@ __all__ = [
     "PublicBodyUploader",
     "PostalUploadForm",
     "MakeProjectPublicForm",
+    "PublishRequestsForm",
     "ApplyModerationForm",
     "AssignProjectForm",
+    "SendMessageProjectForm",
 ]

--- a/froide/foirequest/forms/message.py
+++ b/froide/foirequest/forms/message.py
@@ -100,6 +100,11 @@ class AttachmentSaverMixin(object):
         return added
 
 
+def get_default_initial_message(user):
+    message = _("Dear Sir or Madam,\n\n…\n\nSincerely yours\n%(name)s\n")
+    return message % {"name": user.get_full_name()}
+
+
 def get_send_message_form(*args, **kwargs):
     foirequest = kwargs.pop("foirequest")
     last_message = list(foirequest.messages)[-1]
@@ -125,8 +130,7 @@ def get_send_message_form(*args, **kwargs):
             },
         )
     else:
-        message = _("Dear Sir or Madam,\n\n…\n\nSincerely yours\n%(name)s\n")
-        message = message % {"name": foirequest.user.get_full_name()}
+        message = get_default_initial_message(foirequest.user)
 
     return SendMessageForm(
         *args,

--- a/froide/foirequest/forms/message.py
+++ b/froide/foirequest/forms/message.py
@@ -326,7 +326,7 @@ class SendMessageForm(AttachmentSaverMixin, AddressBaseForm, forms.Form):
         )
         return message
 
-    def save(self, user=None):
+    def save(self, user=None, bulk=False):
         recipient_email = self.cleaned_data["to"]
         message = self.make_message(self.foirequest, recipient_email)
         message.save()
@@ -348,7 +348,7 @@ class SendMessageForm(AttachmentSaverMixin, AddressBaseForm, forms.Form):
 
         message.send(attachments=attachments)
         self.foirequest.message_sent.send(
-            sender=self.foirequest, message=message, user=user
+            sender=self.foirequest, message=message, user=user, bulk=bulk
         )
 
         return message

--- a/froide/foirequest/forms/project.py
+++ b/froide/foirequest/forms/project.py
@@ -4,6 +4,7 @@ from django.utils.translation import gettext_lazy as _
 from froide.foirequest.tasks import create_project_messages
 from froide.helper.widgets import BootstrapCheckboxInput
 
+from ..auth import get_write_foirequest_queryset
 from ..forms import SendMessageForm
 from ..models import FoiProject
 
@@ -38,6 +39,18 @@ class AssignProjectForm(forms.Form):
             project.recalculate_order()
 
         return self.instance
+
+
+class FoiRequestBulkForm(forms.Form):
+    foirequest = forms.ModelMultipleChoiceField(queryset=None)
+
+    def __init__(self, *args, **kwargs):
+        foiproject: FoiProject = kwargs.pop("foiproject")
+        request = kwargs.pop("request")
+        super().__init__(*args, **kwargs)
+        self.fields["foirequest"].queryset = get_write_foirequest_queryset(
+            request, queryset=foiproject.foirequest_set.all()
+        )
 
 
 class PublishRequestsForm(forms.Form):

--- a/froide/foirequest/forms/project.py
+++ b/froide/foirequest/forms/project.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
+from froide.foirequest.forms.message import get_default_initial_message
 from froide.foirequest.tasks import create_project_messages
 from froide.helper.widgets import BootstrapCheckboxInput
 
@@ -77,6 +78,10 @@ class SendMessageProjectForm(SendMessageForm):
 
     def _initialize_fields(self):
         self.fields["address"].initial = self.foiproject.user.address
+        self.fields["message"].initial = get_default_initial_message(
+            self.foiproject.user
+        )
+        self.fields["subject"].initial = self.foiproject.title
 
     def get_user(self):
         return self.foiproject.user

--- a/froide/foirequest/signals.py
+++ b/froide/foirequest/signals.py
@@ -191,11 +191,15 @@ def send_foimessage_sent_confirmation(sender, message=None, **kwargs):
         # All non-email sent messages are not interesting to users.
         # Don't inform them about it.
         return
+    if kwargs.get("bulk"):
+        # Don't notify on bulk message sending
+        return
 
     messages = sender.get_messages()
     start_thread = False
     if len(messages) == 1:
         if sender.project_id is not None:
+            # Don't notify on first message in a project
             return
         subject = _("Your Freedom of Information Request was sent")
         mail_intent = confirm_foi_request_sent_email

--- a/froide/foirequest/tasks.py
+++ b/froide/foirequest/tasks.py
@@ -143,7 +143,7 @@ def create_project_message(foirequest_id, user_id, **form_data):
     form_data["to"] = foirequest.public_body.email
     form = SendMessageForm(foirequest=foirequest, data=form_data)
     if form.is_valid():
-        form.save(user)
+        form.save(user=user, bulk=True)
 
 
 @celery_app.task(name="froide.foirequest.tasks.convert_attachment_task", time_limit=60)

--- a/froide/foirequest/tasks.py
+++ b/froide/foirequest/tasks.py
@@ -113,6 +113,39 @@ def create_project_request(project_id, publicbody_id, sequence=0, **kwargs):
     return foirequest.pk
 
 
+@celery_app.task
+def create_project_messages(foirequest_ids, user_id, **form_data):
+    for req_id in foirequest_ids:
+        create_project_message.delay(req_id, user_id, **form_data)
+
+
+@celery_app.task
+def create_project_message(foirequest_id, user_id, **form_data):
+    from django.contrib.auth import get_user_model
+
+    from froide.foirequest.forms.message import SendMessageForm
+
+    User = get_user_model()
+
+    try:
+        foirequest = FoiRequest.objects.get(id=foirequest_id)
+    except FoiRequest.DoesNotExist:
+        # request does not exist anymore?
+        return
+    assert foirequest.project
+
+    try:
+        user = User.objects.get(id=user_id)
+    except User.DoesNotExist:
+        return
+
+    # Send to public body's default email
+    form_data["to"] = foirequest.public_body.email
+    form = SendMessageForm(foirequest=foirequest, data=form_data)
+    if form.is_valid():
+        form.save(user)
+
+
 @celery_app.task(name="froide.foirequest.tasks.convert_attachment_task", time_limit=60)
 def convert_attachment_task(instance_id):
     try:

--- a/froide/foirequest/templates/foirequest/foiproject_action.html
+++ b/froide/foirequest/templates/foirequest/foiproject_action.html
@@ -1,0 +1,44 @@
+{% extends 'foirequest/base.html' %}
+
+{% load i18n %}
+{% load form_helper %}
+
+{% block title %}{{ object.title }}{% endblock %}
+
+{% block app_body %}
+  <h1>
+    {{ object.title }}
+  </h1>
+
+  <a href="{{ object.get_absolute_url }}" class="btn btn-secondary btn-sm float-right">
+    {% translate "Back to project page " %}
+  </a>
+
+  <p>
+    {{ action.description }}
+  </p>
+
+  <form method="post" action="{% url 'foirequest-project_execute_action' slug=object.slug %}">
+    {% csrf_token %}
+    <input type="hidden" name="action" value="{{ action.action }}"/>
+    <div style="max-height: 20vh" class="border my-2">
+      <ul class="mb-0">
+        {% for foirequest in foirequests %}
+          <li>
+            <input type="hidden" name="foirequest" value="{{ foirequest.pk }}"/>
+            {% blocktranslate with req_id=foirequest.id pb_name=foirequest.public_body.name %}
+            Request to {{ pb_name }} [#{{ req_id }}]
+            {% endblocktranslate %}
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+
+    {% render_form form %}
+
+    <button type="submit" class="btn btn-primary">
+      {{ action.button }}
+    </button>
+  </form>
+
+{% endblock %}

--- a/froide/foirequest/templates/foirequest/foiproject_detail.html
+++ b/froide/foirequest/templates/foirequest/foiproject_detail.html
@@ -84,64 +84,89 @@
     </div>
   {% endif %}
 
-  <div class="table-responsive">
-    <table class="table table-hover table-sm">
-      <thead>
-        <tr>
-          <th scope="col">#</th>
-          <th scope="col">
-            {% trans "status" %}
-          </th>
-          <th scope="col">
-            {% trans "last message" %}
-          </th>
-          <th scope="col">
-            {% trans "public body" %}
-          </th>
-          {% if object|can_read_foiproject_authenticated:request %}
+  <form method="post" action="{% url 'foirequest-project_execute_action' slug=object.slug %}">
+    {% csrf_token %}
+    <input type="hidden" name="actionstep" value="initial"/>
+    <div class="mb-1">
+      <p class="mb-0">
+        {% translate "Perform action for selected requests:" %}
+      </p>
+      {% if object|can_manage_foiproject:request %}
+        <button class="btn btn-light btn-sm ml-2" name="action" value="publish">
+          {% translate "Publish..." %}
+        </button>
+      {% endif %}
+      <button class="btn btn-light btn-sm ml-2" name="action" value="writemessage">
+        {% translate "Write message..." %}
+      </button>
+    </div>
+    <div class="table-responsive">
+      <table class="table table-hover table-sm">
+        <thead>
+          <tr>
             <th scope="col">
-              {% trans "is public?" %}
+              {% if object|can_write_foiproject:request %}
+                <input type="checkbox" data-checkall="foirequest">
+              {% else %}#{% endif %}
             </th>
-          {% endif %}
-        </tr>
-      </thead>
-      <tbody>
-        {% for req in foirequests %}
-        <tr>
-          <td>
-            {{ req.project_number }}
-          </td>
-          <td>
-            <a href="{{ req.get_absolute_url }}">
-              {{ req.get_status_display }}
-            </a>
-          </td>
-          <td>
-            <a href="{{ req.get_absolute_url_last_message }}">
-              {{ req.last_message|date:"SHORT_DATE_FORMAT" }}
-            </a>
-          </td>
-          <td>
-            <a href="{{ req.public_body.get_absolute_url }}">
-              {{ req.public_body.name }}
-            </a>
-          </td>
-          {% if object|can_read_foiproject_authenticated:request %}
-            <td class="text-center">
-              {% if req.is_public %}
-                <span class="fa fa-check"></span>
-                <span class="sr-only">{% translate "Yes" %}</span>
+            <th scope="col">
+              {% trans "status" %}
+            </th>
+            <th scope="col">
+              {% trans "last message" %}
+            </th>
+            <th scope="col">
+              {% trans "public body" %}
+            </th>
+            {% if object|can_read_foiproject_authenticated:request %}
+              <th scope="col">
+                {% trans "is public?" %}
+              </th>
+            {% endif %}
+          </tr>
+        </thead>
+        <tbody>
+          {% for req in foirequests %}
+          <tr>
+            <td>
+              {% if object|can_write_foiproject:request %}
+                <input type="checkbox" name="foirequest" value="{{ req.id }}">
               {% else %}
-                <span class="fa fa-ban"></span>
-                <span class="sr-only">{% translate "No" %}</span>
+                {{ req.project_number }}
               {% endif %}
             </td>
-          {% endif %}
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
+            <td>
+              <a href="{{ req.get_absolute_url }}">
+                {{ req.get_status_display }}
+              </a>
+            </td>
+            <td>
+              <a href="{{ req.get_absolute_url_last_message }}">
+                {{ req.last_message|date:"SHORT_DATE_FORMAT" }}
+              </a>
+            </td>
+            <td>
+              <a href="{{ req.public_body.get_absolute_url }}">
+                {{ req.public_body.name }}
+              </a>
+            </td>
+            {% if object|can_read_foiproject_authenticated:request %}
+              <td class="text-center">
+                {% if req.is_public %}
+                  <span class="fa fa-check"></span>
+                  <span class="sr-only">{% translate "Yes" %}</span>
+                {% else %}
+                  <span class="fa fa-ban"></span>
+                  <span class="sr-only">{% translate "No" %}</span>
+                {% endif %}
+              </td>
+            {% endif %}
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </form>
 
   {% if team_form %}
     {% trans "Assign team to project" as legend %}

--- a/froide/foirequest/urls/project_urls.py
+++ b/froide/foirequest/urls/project_urls.py
@@ -1,6 +1,11 @@
 from django.urls import path
 
-from ..views import ProjectView, SetProjectTeamView, make_project_public
+from ..views import (
+    ProjectActionView,
+    ProjectView,
+    SetProjectTeamView,
+    make_project_public,
+)
 
 urlpatterns = [
     path("<slug:slug>/", ProjectView.as_view(), name="foirequest-project"),
@@ -13,5 +18,10 @@ urlpatterns = [
         "<slug:slug>/make-public/",
         make_project_public,
         name="foirequest-project_make_public",
+    ),
+    path(
+        "<slug:slug>/action/",
+        ProjectActionView.as_view(),
+        name="foirequest-project_execute_action",
     ),
 ]

--- a/froide/foirequest/views/__init__.py
+++ b/froide/foirequest/views/__init__.py
@@ -43,6 +43,7 @@ from .misc_views import (
     index,
 )
 from .project import (
+    ProjectActionView,
     ProjectView,
     SetProjectTeamView,
     make_project_public,
@@ -110,6 +111,7 @@ __all__ = [
     "SetTeamView",
     "FoiRequestSitemap",
     "ProjectView",
+    "ProjectActionView",
     "project_shortlink",
     "SetProjectTeamView",
     "make_project_public",

--- a/froide/foirequest/views/message.py
+++ b/froide/foirequest/views/message.py
@@ -63,10 +63,10 @@ def send_message(request, foirequest):
             request, messages.SUCCESS, _("Your message has been sent.")
         )
         return redirect(mes)
-    else:
-        return show_foirequest(
-            request, foirequest, context={"send_message_form": form}, status=400
-        )
+
+    return show_foirequest(
+        request, foirequest, context={"send_message_form": form}, status=400
+    )
 
 
 @require_POST

--- a/froide/foirequest/views/project.py
+++ b/froide/foirequest/views/project.py
@@ -1,7 +1,13 @@
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from django.forms import Form
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
+from django.utils.functional import cached_property
+from django.utils.translation import gettext
 from django.views.decorators.http import require_POST
-from django.views.generic import DetailView
+from django.views.generic import DetailView, UpdateView
 
 from froide.helper.utils import render_400, render_403
 from froide.team.forms import AssignTeamForm
@@ -10,9 +16,10 @@ from froide.team.views import AssignTeamView
 from ..auth import (
     can_manage_foiproject,
     can_read_foiproject,
+    can_write_foiproject,
     get_read_foirequest_queryset,
 )
-from ..forms import MakeProjectPublicForm
+from ..forms import MakeProjectPublicForm, PublishRequestsForm, SendMessageProjectForm
 from ..models import FoiProject
 
 
@@ -49,17 +56,109 @@ class ProjectView(AuthRequiredMixin, DetailView):
         public_requests = self.object.foirequest_set.filter(public=True).count()
         context["foirequests"] = get_read_foirequest_queryset(
             self.request, queryset=self.object.foirequest_set.all()
-        )
+        ).prefetch_related("public_body")
         context["public_requests"] = public_requests
         context["all_public"] = public_requests == self.object.request_count
         context["all_non_public"] = public_requests == 0
-        if not context["all_public"] or not self.object.public:
-            context["make_public_form"] = MakeProjectPublicForm()
         if can_manage_foiproject(self.object, self.request):
+            if not context["all_public"] or not self.object.public:
+                context["make_public_form"] = MakeProjectPublicForm()
             context["team_form"] = AssignTeamForm(
                 instance=self.object, user=self.request.user
             )
+
         return context
+
+
+@dataclass
+class ProjectAction:
+    action: str
+    auth_check: callable
+    form_class: Form
+    button: str
+    description: str
+
+
+class ProjectActionView(UpdateView):
+    model = FoiProject
+    template_name = "foirequest/foiproject_action.html"
+
+    @cached_property
+    def actions(self):
+        actions = (
+            ProjectAction(
+                action="publish",
+                auth_check=can_manage_foiproject,
+                form_class=PublishRequestsForm,
+                button=gettext("Publish"),
+                description=gettext("Publish selected requests."),
+            ),
+            ProjectAction(
+                action="writemessage",
+                auth_check=can_write_foiproject,
+                form_class=SendMessageProjectForm,
+                description=gettext(
+                    "Write message to public body in selected requests."
+                ),
+                button=gettext("Send messages"),
+            ),
+        )
+        return {a.action: a for a in actions}
+
+    def get_object(self, queryset=None):
+        obj = super().get_object(queryset=queryset)
+        if not can_read_foiproject(obj, self.request):
+            raise Http404
+        return obj
+
+    def get(self, request, *args, **kwargs):
+        return redirect(self.get_object())
+
+    def get_foirequests(self):
+        return self.object.foirequest_set.filter(
+            id__in=self.request.POST.getlist("foirequest", [])
+        )
+
+    def post(self, request, *args, **kwargs):
+        action = self.get_action()
+        self.object = self.get_object()
+        if not action.auth_check(self.object, request):
+            raise Http404
+        foirequests = self.get_foirequests()
+        if self.is_initial_step():
+            form = action.form_class(foiproject=self.object, foirequests=foirequests)
+            context = self.get_context_data(form=form, foirequests=foirequests)
+            return self.render_to_response(context)
+
+        form = action.form_class(
+            request.POST, foiproject=self.object, foirequests=foirequests
+        )
+        if form.is_valid():
+            return self.form_valid(form)
+        context = self.get_context_data(form=form, foirequests=foirequests)
+        return self.render_to_response(context)
+
+    def is_initial_step(self):
+        return self.request.POST.get("actionstep") == "initial"
+
+    def get_action(self):
+        action = self.request.POST.get("action")
+        if action not in self.actions:
+            raise Http404
+        return self.actions[action]
+
+    def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
+        ctx = super().get_context_data(**kwargs)
+        ctx["action"] = self.get_action()
+        return ctx
+
+    def form_valid(self, form):
+        """If the form is valid, save the associated model."""
+        self.object = form.save(self.request.user)
+        return redirect(self.get_success_url())
+
+    def get_success_url(self) -> str:
+        return self.object.get_absolute_url()
 
 
 class SetProjectTeamView(AssignTeamView):

--- a/froide/letter/utils.py
+++ b/froide/letter/utils.py
@@ -132,7 +132,6 @@ class MessageSender:
             },
             files=MultiValueDict({"sendmessage-files": [letter]}),
             foirequest=self.foirequest,
-            message_ready=True,
         )
         message_form.is_valid()
         sent_message = message_form.save()

--- a/frontend/javascript/snippets/misc.ts
+++ b/frontend/javascript/snippets/misc.ts
@@ -38,6 +38,22 @@ const runOnPage = (): void => {
     }
   })
 
+  document
+    .querySelectorAll<HTMLInputElement>('input[data-checkall]')
+    .forEach((checkbox) => {
+      checkbox.addEventListener('change', () => {
+        const checkboxName = checkbox.dataset.checkall
+        if (checkboxName == null) {
+          return
+        }
+        document
+          .querySelectorAll<HTMLInputElement>(`input[name="${checkboxName}"]`)
+          .forEach((el) => {
+            el.checked = checkbox.checked
+          })
+      })
+    })
+
   document.querySelectorAll<HTMLElement>('[data-scrollto]').forEach((link) => {
     link.addEventListener('click', (e) => {
       if (link.dataset.scrollto) {


### PR DESCRIPTION
Similar to Django admin actions, project actions let you select requests from the project page and apply bulk actions to them. Included in this PR are publishing the request and writing a message in the request.