### PR TITLE
Requester comments

### DIFF
--- a/froide/comments/templates/froide_comments/comment.html
+++ b/froide/comments/templates/froide_comments/comment.html
@@ -7,7 +7,7 @@
     {# name #}
     <strong class="text-truncate">
       {% if request.user.is_authenticated %}
-        {% if comment.user == object.user and object.user.private %}
+        {% if comment.is_requester and object.user.private %}
           <span class="redacted-dummy redacted-hover" data-toggle="tooltip" title="{% trans 'Name not public' %}">
             {% trans "Commentator" %}
           </span>
@@ -22,7 +22,7 @@
     </strong>
     
     {# requester-/moderator-badges #}
-    {% if comment.user == object.user %}
+    {% if comment.is_requester %}
       <span class="badge bg-blue-20 ml-1">{% trans "Requester" %}</span>
     {% elif comment.is_moderator %}
       <span class="badge bg-yellow-100 ml-1">{% trans "Moderator" %}</span>

--- a/froide/comments/templates/froide_comments/comment.html
+++ b/froide/comments/templates/froide_comments/comment.html
@@ -4,10 +4,10 @@
 
   {# head #}
   <div class="d-flex justify-content-start align-items-center flex-nowrap">
-    {# name #}
     <strong class="text-truncate">
       {% if request.user.is_authenticated %}
-        {% if comment.is_requester and object.user.private %}
+        {# name #}
+        {% if comment.is_requester and comment.user.private %}
           <span class="redacted-dummy redacted-hover" data-toggle="tooltip" title="{% trans 'Name not public' %}">
             {% trans "Commentator" %}
           </span>
@@ -16,18 +16,19 @@
         {% else %}
           {{ comment.user_name }}
         {% endif %}
+
+        {# requester-/moderator-badges #}
+        {% if comment.is_requester %}
+          <span class="badge bg-blue-20 ml-1">{% trans "Requester" %}</span>
+        {% elif comment.is_moderator %}
+          <span class="badge bg-yellow-100 ml-1">{% trans "Moderator" %}</span>
+        {% endif %}
+
       {% else %}
         <span class="text-muted font-italic">{% trans "Only visible if logged in" %}</span>
       {% endif %}
     </strong>
-    
-    {# requester-/moderator-badges #}
-    {% if comment.is_requester %}
-      <span class="badge bg-blue-20 ml-1">{% trans "Requester" %}</span>
-    {% elif comment.is_moderator %}
-      <span class="badge bg-yellow-100 ml-1">{% trans "Moderator" %}</span>
-    {% endif %}
-    
+
     {# timestamp #}
     <small class="text-gray-600 mx-1">•</small>
     <small class="text-nowrap text-gray-600">{{ comment.submit_date }}</small>

--- a/froide/foirequest/templatetags/foirequest_tags.py
+++ b/froide/foirequest/templatetags/foirequest_tags.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 
 from django import template
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Count, Q
+from django.db.models import Case, Count, Q, Value, When
 from django.template.defaultfilters import truncatechars_html
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
@@ -376,7 +376,11 @@ def get_comment_list(context, message):
                 is_moderator=Count(
                     "user__groups__permissions",
                     filter=Q(user__groups__permissions__codename="moderate"),
-                )
+                ),
+                is_requester=Case(
+                    When(user=foirequest.user, then=Value(1)),
+                    default=Value(0),
+                ),
             )
             .order_by("-submit_date")
             .select_related("user")


### PR DESCRIPTION
[🐛 Fix requester badge on comments](https://github.com/okfde/froide/commit/d0a8ff18f25dc7e183f7c2057ad1b70378184e9b) fixes a bug that caused the "Requester"-badge no never be shown.

The second comment closes #539 by not showing the badges if the viewer is not logged in. This also applies to the modator-badge