### PR TITLE
✨ Allow finetuning of actions needed for ModerationTrigger to be applied

### DIFF
--- a/froide/foirequest/moderation.py
+++ b/froide/foirequest/moderation.py
@@ -175,7 +175,11 @@ def get_moderation_triggers(
             resolve_moderation_action(*action_args)
             for action_args in trigger["actions"]
         ]
-        is_applied = all(a.is_applied(foirequest) for a in actions)
+        all_action_idx = range(len(actions))
+        is_applied = all(
+            actions[idx].is_applied(foirequest)
+            for idx in trigger.get("applied_if_actions_applied", all_action_idx)
+        )
         triggers[trigger["name"]] = ModerationTrigger(
             name=trigger["name"],
             label=trigger["label"],

--- a/froide/settings.py
+++ b/froide/settings.py
@@ -532,6 +532,7 @@ class Base(Configuration):
                 "name": "nonfoi",
                 "label": _("Non-FOI"),
                 "icon": "fa-ban",
+                "applied_if_actions_applied": [0],
                 "actions": [
                     ("froide.foirequest.moderation.MarkNonFOI",),
                     (


### PR DESCRIPTION
At the moment, triggers that send an email are *always* considered not applied, because SendUserEmail.is_applied always returns False. This PR allows more control over which actions are needed for a trigger to be considered applied, thus allowing us to ignore the SendUserEmail action