### PR TITLE
🐛 Include automatic redactions when counting redactions

### DIFF
--- a/frontend/javascript/components/redaction/redaction.vue
+++ b/frontend/javascript/components/redaction/redaction.vue
@@ -311,8 +311,8 @@ export default {
       return this.actionIndexPerPage[this.currentPage] < actions.length
     },
     hasRedactions() {
-      for (const p in this.actionsPerPage) {
-        if (this.actionIndexPerPage[p] > 0) {
+      for (const p in this.rectanglesPerPage) {
+        if (this.rectanglesPerPage[p].length > 0) {
           return true
         }
       }


### PR DESCRIPTION
Until hasRedactions checked if there were manual redactions. This lead to

1. The frontend showing the green "no redactions needed" as the only button, even if automatic redactions existed
2. No confirmation (#535) being shown when selecting this button