### PR TITLE
Fix public body proposal accepting

### DIFF
--- a/froide/publicbody/templates/publicbody/snippets/publicbody_proposals.html
+++ b/froide/publicbody/templates/publicbody/snippets/publicbody_proposals.html
@@ -29,7 +29,7 @@
       </td>
       <td>
         <div class="form-check">
-          <input class="form-check-input" type="radio" id="proposal_id' name="proposal_id" class="proposal" value="" required>
+          <input class="form-check-input proposal" type="radio" id="proposal_id" name="proposal_id" value="" required>
           <label class="form-label" for="proposal_id">
             {% trans "Change, without accepting" %}
           </label>
@@ -38,7 +38,7 @@
       {% for key, proposal in proposals.items %}
         <td>
           <div class="form-check">
-            <input class="form-check-input" type="radio" name="proposal_id" id="proposal_id-{{ key }}" class="proposal" value="{{ key }}" required>
+            <input class="form-check-input proposal" type="radio" name="proposal_id" id="proposal_id-{{ key }}" value="{{ key }}" required>
             <label class="form-check-label" for="proposal_id-{{ key }}">
                 {% trans "Accept this proposal" %}
             </label>


### PR DESCRIPTION
This PR aims to fix #581

It seems that the issue was caused by
1. having multiple `class` attributes on html elements and
2. by an issue where `'` was used instead of `"` to end an html attribute's value

This PR merges the multiple `class` attributes into single ones and replaces the `'` with `"`.