### PR TITLE
Remove 'done' button from upload dashboard, allow individual upload file removal

### DIFF
--- a/frontend/javascript/components/publicbodyupload/publicbody-upload.vue
+++ b/frontend/javascript/components/publicbodyupload/publicbody-upload.vue
@@ -18,6 +18,7 @@
       :config="config"
       class="mb-3 mt-3"
       :auto-proceed="true"
+      :allow-remove="false"
       :required="true"
       @ready="canSubmit = $event"
       @uploading="uploading = $event" />

--- a/frontend/javascript/components/upload/file-uploader.vue
+++ b/frontend/javascript/components/upload/file-uploader.vue
@@ -61,6 +61,11 @@ export default {
       type: Boolean,
       default: false,
       required: false
+    },
+    allowRemove: {
+      type: Boolean,
+      default: true,
+      required: false
     }
   },
   data() {
@@ -123,7 +128,9 @@ export default {
       target: this.$refs.uppy,
       height: 250,
       showLinkToFileUploadResult: false,
-      proudlyDisplayPoweredByUppy: false
+      proudlyDisplayPoweredByUppy: false,
+      showRemoveButtonAfterComplete: this.allowRemove,
+      doneButtonHandler: null
     })
     this.uppy.use(Tus, {
       endpoint: this.config.url.tusEndpoint,


### PR DESCRIPTION
Form submit handles the upload later, so no done button needed.