### PR TITLE
Add fake PDFjs pdf.worker.js.map file

### DIFF
--- a/froide/static/js/pdf.worker.js.map
+++ b/froide/static/js/pdf.worker.js.map
@@ -1,0 +1,3 @@
+{
+    "comment": "Fake stand-in file because frontend build may add pdf.worker.js.map file."
+}

--- a/frontend/javascript/components/docupload/pdf-preview.vue
+++ b/frontend/javascript/components/docupload/pdf-preview.vue
@@ -17,9 +17,6 @@
 
 <script>
 import PDFJSWorkerUrl from 'pdfjs-dist/build/pdf.worker.js?url'
-// Reference map so it gets copied on build
-// eslint-disable-next-line no-unused-vars
-import PDFJSWorkerUrlMap from 'pdfjs-dist/build/pdf.worker.js.map?url'
 
 const range = (len) => [...Array(len).keys()]
 

--- a/frontend/javascript/components/redaction/pdf-redaction.vue
+++ b/frontend/javascript/components/redaction/pdf-redaction.vue
@@ -221,9 +221,6 @@ import 'string.prototype.repeat'
 import ConfirmNoRedaction from './confirm-no-redaction'
 
 import PDFJSWorkerUrl from 'pdfjs-dist/build/pdf.worker.js?url'
-// Reference map so it gets copied on build
-// eslint-disable-next-line no-unused-vars
-import PDFJSWorkerUrlMap from 'pdfjs-dist/build/pdf.worker.js.map?url'
 
 import range from 'lodash.range'
 


### PR DESCRIPTION
So Django 4.0+ manifest static file storage collectstatic can resolve the source mapping reference, even when the file is not available in frontend build.