### PR TITLE
🐛 fix crash in form modal hiding

### DIFF
--- a/frontend/javascript/snippets/form-ajax.ts
+++ b/frontend/javascript/snippets/form-ajax.ts
@@ -54,8 +54,12 @@ function submitFormsAjax(): void {
           const modalTrigger = document.getElementById(
             form.dataset.modal
           ) as IHTMLModalTriggerElement
-          if (modalTrigger) {
-            modalTrigger.Modal.hide()
+          if (modalTrigger?.dataset?.bsTarget) {
+            Modal.getInstance(
+              document.querySelector(
+                modalTrigger.dataset.bsTarget
+              ) as HTMLElement
+            )?.hide()
           }
         }
 


### PR DESCRIPTION
`{el}.Modal` doesn't seem to exist (anymore? maybe it did bs4?)