### PR TITLE
Add profile picture to request page + housekeeping

### DIFF
--- a/froide/account/forms.py
+++ b/froide/account/forms.py
@@ -580,6 +580,9 @@ class ProfileForm(forms.ModelForm):
         self.fields["profile_photo"].help_text = _(
             "Image must be square and between 480 to 960 pixels " "in both dimensions."
         )
+        self.old_profile_photo = None
+        if self.instance.profile_photo:
+            self.old_profile_photo = self.instance.profile_photo
 
     def clean_profile_photo(self):
         image_field = self.cleaned_data["profile_photo"]
@@ -595,6 +598,12 @@ class ProfileForm(forms.ModelForm):
         if image.width > self.DIMS[1]:
             raise forms.ValidationError(_("Image dimensions are too large."))
         return image_field
+
+    def save(self, commit=True):
+        if not self.cleaned_data["profile_photo"] and self.old_profile_photo:
+            self.instance.profile_photo = self.old_profile_photo
+            self.instance.delete_profile_photo()
+        return super().save(commit=commit)
 
 
 class AccountSettingsForm(forms.ModelForm):

--- a/froide/account/models.py
+++ b/froide/account/models.py
@@ -23,7 +23,7 @@ from taggit.managers import TaggableManager
 from taggit.models import TagBase, TaggedItemBase
 
 from froide.helper.csv_utils import export_csv, get_dict
-from froide.helper.storage import HashedFilenameStorage
+from froide.helper.storage import HashedFilenameStorage, delete_file_if_last_reference
 
 
 class UserTag(TagBase):
@@ -322,6 +322,11 @@ class User(AbstractBaseUser, PermissionsMixin):
     def deactivate_and_block(self):
         self.is_blocked = True
         self.deactivate()
+
+    def delete_profile_photo(self):
+        if self.profile_photo:
+            delete_file_if_last_reference(self, "profile_photo", delete_prefix=True)
+            self.profile_photo = None
 
 
 class Application(AbstractApplication):

--- a/froide/account/utils.py
+++ b/froide/account/utils.py
@@ -91,7 +91,7 @@ def make_account_private(user):
     user.organization_url = ""
     user.profile_text = ""
     if user.profile_photo:
-        user.profile_photo.delete(save=False)
+        user.delete_profile_photo()
     user.save()
 
     make_account_private_task.delay(user.id)

--- a/froide/foirequest/templates/foirequest/body/message/message.html
+++ b/froide/foirequest/templates/foirequest/body/message/message.html
@@ -4,9 +4,9 @@
 {% load problemreport_tags %}
 {% load guidance_tags %}
 {% load content_helper %}
+{% load thumbnail %}
 
 {% get_comment_list message as comment_list %}
-
 
 {% block before_message_container %}{% endblock %}
 
@@ -19,7 +19,11 @@
 
     {# avatar #}
     <div class="alpha-message__avatar alpha-message__avatar--{% if message.is_response %}{% if message.is_mediator %}shield{% else %}house{% endif %}{% else %}user{% endif %}">
-      <i class="fa fa-{% if message.is_response %}{% if message.is_mediator %}shield{% else %}bank{% endif %}{% else %}user{% endif %}" aria-hidden="true"></i>
+      {% if not message.is_response and not message.sender_user.private and message.sender_user.profile_photo %}
+        <img src="{% thumbnail message.sender_user.profile_photo 64x64 %}" alt="{{ message.sender_user.get_full_name }}" class="img-fluid rounded-circle">
+      {% else %}
+        <i class="fa fa-{% if message.is_response %}{% if message.is_mediator %}shield{% else %}bank{% endif %}{% else %}user{% endif %}" aria-hidden="true"></i>
+      {% endif %}
     </div>
 
     {# sender, recipient, message preview, meta infos #}

--- a/froide/settings.py
+++ b/froide/settings.py
@@ -48,6 +48,7 @@ class Base(Configuration):
             "django_json_widget",
             "django_celery_beat",
             "mfa",
+            "easy_thumbnails",
             # local
             "froide.foirequest",
             "froide.follow",

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -152,6 +152,7 @@ django==4.0.7
     #   django-taggit
     #   django-treebeard
     #   djangorestframework
+    #   easy-thumbnails
 django-appconf==1.0.4
     # via django-celery-email
 django-cache-url==3.2.3
@@ -217,6 +218,8 @@ dnspython==2.1.0
     # via pyisemail
 docopt==0.6.2
     # via coveralls
+easy-thumbnails==2.8.3
+    # via -r requirements.in
 elasticsearch==7.13.2
     # via
     #   -r requirements.in
@@ -346,6 +349,7 @@ pillow==9.2.0
     #   -r requirements.in
     #   cairosvg
     #   django-filingcabinet
+    #   easy-thumbnails
     #   pikepdf
     #   reportlab
     #   weasyprint
@@ -375,6 +379,8 @@ pycodestyle==2.7.0
     #   flake8
 pycparser==2.20
     # via cffi
+pycryptodome==3.15.0
+    # via django-filingcabinet
 pyflakes==2.3.1
     # via
     #   -r requirements-test.in

--- a/requirements.in
+++ b/requirements.in
@@ -24,6 +24,7 @@ Django>=4.0,<4.1
 djangorestframework
 djangorestframework-csv
 djangorestframework-jsonp
+easy-thumbnails
 elasticsearch-dsl>=7.0.0<8.0.0
 elasticsearch<8.0.0,>=7.0.0
 geoip2

--- a/requirements.txt
+++ b/requirements.txt
@@ -124,6 +124,7 @@ django==4.0.7
     #   django-taggit
     #   django-treebeard
     #   djangorestframework
+    #   easy-thumbnails
 django-appconf==1.0.4
     # via django-celery-email
 django-cache-url==3.2.3
@@ -181,6 +182,8 @@ djangorestframework-jsonp==1.0.2
     # via -r requirements.in
 dnspython==2.1.0
     # via pyisemail
+easy-thumbnails==2.8.3
+    # via -r requirements.in
 elasticsearch==7.13.2
     # via
     #   -r requirements.in
@@ -257,6 +260,7 @@ pillow==9.2.0
     #   -r requirements.in
     #   cairosvg
     #   django-filingcabinet
+    #   easy-thumbnails
     #   pikepdf
     #   reportlab
     #   weasyprint
@@ -272,6 +276,8 @@ pyasn1-modules==0.2.8
     # via service-identity
 pycparser==2.20
     # via cffi
+pycryptodome==3.15.0
+    # via django-filingcabinet
 pygtail==0.12.0
     # via -r requirements.in
 pyisemail==1.3.2

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         "pygtail",
         "django-filingcabinet",
         "icalendar",
+        "easy-thumbnails",
     ],
     extras_require=extras,
     include_package_data=True,


### PR DESCRIPTION
- Add profile picture on request page with thumbnailing.
- Add function to make sure files in `HashedFileStorage` are deleted if last reference is gone.
- Properly delete profile photos and their thumbnails when requested.

Needs to be deployed with a `fragdenstaat_de` change that removes `easy_thumbnails` from its additional installed apps.

Similar thing should be handled for organisation logos!