### PR TITLE
👽️ rename `get_pdf_viewer` to `get_pdf_viewer_url`

### DIFF
--- a/froide/foirequest/templates/foirequest/attachment/show.html
+++ b/froide/foirequest/templates/foirequest/attachment/show.html
@@ -61,7 +61,7 @@
 {% if attachment.can_embed %}
   {% if attachment.is_pdf %}
     <div class="container-sm-full d-none d-md-block">
-      <iframe src="{% get_pdf_viewer attachment_url %}" frameborder="0" style="width: 100%; height: 90vh; border: 0;">
+      <iframe src="{% get_pdf_viewer_url attachment_url %}" frameborder="0" style="width: 100%; height: 90vh; border: 0;">
       </iframe>
     </div>
     <div class="container d-block d-md-none text-center">


### PR DESCRIPTION
see okfde/django-filingcabinet#30
