### PR TITLE
✨ Link profile picture and name to profile

### DIFF
--- a/froide/foirequest/templates/foirequest/body/message/message.html
+++ b/froide/foirequest/templates/foirequest/body/message/message.html
@@ -20,7 +20,7 @@
     {# avatar #}
     <div class="alpha-message__avatar alpha-message__avatar--{% if message.is_response %}{% if message.is_mediator %}shield{% else %}house{% endif %}{% else %}user{% endif %}">
       {% if not message.is_response and not message.sender_user.private and message.sender_user.profile_photo %}
-        <img src="{% thumbnail message.sender_user.profile_photo 64x64 %}" alt="{{ message.sender_user.get_full_name }}" class="img-fluid rounded-circle">
+        <a href="{% url "account-profile" slug=message.sender_user.username %}"><img src="{% thumbnail message.sender_user.profile_photo 64x64 %}" alt="{{ message.sender_user.get_full_name }}" class="img-fluid rounded-circle"></a>
       {% else %}
         <i class="fa fa-{% if message.is_response %}{% if message.is_mediator %}shield{% else %}bank{% endif %}{% else %}user{% endif %}" aria-hidden="true"></i>
       {% endif %}

--- a/froide/foirequest/templates/foirequest/body/message/sender.html
+++ b/froide/foirequest/templates/foirequest/body/message/sender.html
@@ -21,11 +21,13 @@
     {% else %}
       {% if object.user.private %}
         <span class="redacted-dummy redacted-hover" data-bs-toggle="tooltip" title="{% trans 'Only visible to you' %}">
+          {{ message.user_real_sender }}
+        </span>
       {% else %}
-        <span>
+        <a href="{% url "account-profile" slug=message.sender_user.username %}">
+          {{ message.user_real_sender }}
+        </a>
       {% endif %}
-        {{ message.user_real_sender }}
-      </span>
     {% endif %}
     </span>
   {% else %}

--- a/frontend/javascript/components/request/Message.ts
+++ b/frontend/javascript/components/request/Message.ts
@@ -77,7 +77,6 @@ export default class Message {
 
   onHeadClick(e: Event): void {
     this.toggleMessage()
-    e.preventDefault()
   }
 
   toggleMessage(): void {


### PR DESCRIPTION
@krmax44 I'm not entirely sure about the styling. Right now the sender name is highlighted in blue, which is nice to make it clear that it is a link, but IMHO looks strange. What is your opinion on the styling of the link?

<img width="778" alt="Screenshot of a message. The requester name is highlighted in blue" src="https://user-images.githubusercontent.com/6545097/208161927-75100801-39c6-4962-8650-46309c0d4930.png">
