### PR TITLE
🚀 Use local swagger ui for drf-spectacular

### DIFF
--- a/froide/settings.py
+++ b/froide/settings.py
@@ -75,6 +75,7 @@ class Base(Configuration):
             "oauth2_provider",
             "rest_framework",
             "drf_spectacular",
+            "drf_spectacular_sidecar",
         ]
     )
 
@@ -649,6 +650,12 @@ class Base(Configuration):
     UNSUBSCRIBE_EMAIL_ACCOUNT_NAME = values.Value("")
     UNSUBSCRIBE_EMAIL_ACCOUNT_PASSWORD = values.Value("")
     UNSUBSCRIBE_EMAIL_USE_SSL = values.Value(False)
+
+    SPECTACULAR_SETTINGS = {
+        "SWAGGER_UI_DIST": "SIDECAR",
+        "SWAGGER_UI_FAVICON_HREF": "SIDECAR",
+        "REDOC_DIST": "SIDECAR",
+    }
 
 
 class Dev(Base):

--- a/froide/urls.py
+++ b/froide/urls.py
@@ -7,7 +7,7 @@ from django.template.response import TemplateResponse
 from django.urls import include, path, reverse
 from django.utils.translation import pgettext_lazy
 
-from drf_spectacular.views import SpectacularRedocView, SpectacularSwaggerView
+from drf_spectacular.views import SpectacularSwaggerView
 from rest_framework.schemas import get_schema_view
 
 from froide.account.api_views import ProfileView, UserPreferenceView
@@ -135,11 +135,6 @@ if settings.FROIDE_CONFIG.get("api_activated", True):
             "api/v1/schema/swagger-ui/",
             SpectacularSwaggerView.as_view(url_name="schema"),
             name="swagger-ui",
-        ),
-        path(
-            "api/v1/schema/redoc/",
-            SpectacularRedocView.as_view(url_name="schema"),
-            name="redoc",
         ),
     ]
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -115,6 +115,7 @@ django==4.1.4
     #   django-treebeard
     #   djangorestframework
     #   drf-spectacular
+    #   drf-spectacular-sidecar
     #   easy-thumbnails
 django-appconf==1.0.5
     # via django-celery-email
@@ -178,8 +179,10 @@ djangorestframework-jsonp==1.0.2
     # via -r requirements.in
 dnspython==2.2.1
     # via pyisemail
-drf-spectacular==0.25.1
+drf-spectacular[sidecar]==0.25.1
     # via -r requirements.in
+drf-spectacular-sidecar==2022.12.1
+    # via drf-spectacular
 easy-thumbnails==2.8.4
     # via -r requirements.in
 elasticsearch==7.17.8

--- a/requirements.in
+++ b/requirements.in
@@ -23,7 +23,7 @@ Django>=4.1,<4.2
 djangorestframework
 djangorestframework-csv
 djangorestframework-jsonp
-drf-spectacular
+drf-spectacular[sidecar]
 easy-thumbnails
 elasticsearch-dsl>=7.0.0<8.0.0
 elasticsearch<8.0.0,>=7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -100,6 +100,7 @@ django==4.1.4
     #   django-treebeard
     #   djangorestframework
     #   drf-spectacular
+    #   drf-spectacular-sidecar
     #   easy-thumbnails
 django-appconf==1.0.5
     # via django-celery-email
@@ -157,8 +158,10 @@ djangorestframework-jsonp==1.0.2
     # via -r requirements.in
 dnspython==2.2.1
     # via pyisemail
-drf-spectacular==0.25.1
+drf-spectacular[sidecar]==0.25.1
     # via -r requirements.in
+drf-spectacular-sidecar==2022.12.1
+    # via drf-spectacular
 easy-thumbnails==2.8.4
     # via -r requirements.in
 elasticsearch==7.17.8

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         "django-filingcabinet",
         "icalendar",
         "easy-thumbnails",
-        "drf-spectacular",
+        "drf-spectacular[sidecar]",
     ],
     extras_require=extras,
     include_package_data=True,


### PR DESCRIPTION
This commit disabled redoc, because it is not easily possible to deploy a redoc copy that does not load external resources