### PR TITLE
♻️ Replace exif-js with exifreade; fix exif support detection; cache image

### DIFF
--- a/frontend/javascript/components/docupload/document-uploader.vue
+++ b/frontend/javascript/components/docupload/document-uploader.vue
@@ -202,16 +202,16 @@ export default {
     testExifSupport() {
       /*
       From Modernizr feature detection:
-      https://github.com/Modernizr/Modernizr/blob/master/feature-detects/exif-orientation.js
+      https://github.com/Modernizr/Modernizr/blob/master/feature-detects/img/exif-orientation.js
       */
       const img = new Image()
       img.src =
         'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/4QAiRXhpZgAASUkqAAgAAAABABIBAwABAAAABgASAAAAAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAARCAABAAIDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD+/iiiigD/2Q=='
       img.onload = () => {
-        document.body.appendChild(img)
-        const rect = img.getBoundingClientRect()
-        this.$root.exifSupport = this.exifSupport = rect.height === 2
-        document.body.removeChild(img)
+        this.$root.exifSupport = this.exifSupport = img.height === 2
+      }
+      img.onerror = () => {
+        this.$root.exifSupport = this.exifSupport = false
       }
     },
     addAttachmentFromTus(uploadUrl) {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "bootstrap": "^5.2.0",
     "choices.js": "^10.1.0",
     "driver.js": "^0.9.8",
-    "exif-js": "^2.3.0",
+    "exifreader": "^4.9.1",
     "font-awesome": "^4.7.0",
     "js-base64": "3.6.1",
     "leaflet": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -78,5 +78,12 @@
     "vue-slide-up-down": "^2.0.1",
     "vuedraggable": "^2.23.2",
     "vuex": "^3.1.1"
+  },
+  "exifreader": {
+    "include": {
+      "exif": [
+        "Orientation"
+      ]
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -333,6 +333,11 @@
     postcss "^8.4.14"
     source-map "^0.6.1"
 
+"@xmldom/xmldom@^0.7.8":
+  version "0.7.9"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.9.tgz#7f9278a50e737920e21b297b8a35286e9942c056"
+  integrity sha512-yceMpm/xd4W2a85iqZyO09gTnHvXF6pyiWjD2jcOJs7hRoZtNNOO1eJlhHj1ixA+xip2hOyGn+LgcvLCMo5zXA==
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -1246,15 +1251,17 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-exif-js@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/exif-js/-/exif-js-2.3.0.tgz#9d10819bf571f873813e7640241255ab9ce1a814"
-  integrity sha512-1Og9pAzG2FZRVlaavH8bB8BTeHcjMdJhKmeQITkX+uLRCD0xPtKAdZ2clZmQdJ56p9adXtJ8+jwrGp/4505lYg==
-
 exifr@^7.0.0:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/exifr/-/exifr-7.1.3.tgz#f6218012c36dbb7d843222011b27f065fddbab6f"
   integrity sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw==
+
+exifreader@^4.9.1:
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/exifreader/-/exifreader-4.9.1.tgz#e40235845914f42aaf717ffede8367c4f3698e76"
+  integrity sha512-lcVG6VuSkPVHdmM6HybcVWaE8iO4Qq68qFPCRM6U3kz0JODqw4mjMySJ1nZSHfAnrfsIYGfN9A2vh96b3LAF1g==
+  optionalDependencies:
+    "@xmldom/xmldom" "^0.7.8"
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"


### PR DESCRIPTION
This commit improves the handling of uploaded images in the document uploader of the attachment management component (i.e. the thing where you create a document out of uploaded images). It does three things:

1. It replaces the library we use for exif detection in the images. Until now we used exif-js which is no longer maintained and does not work in strict mode
2. It fixes the exif support feature detection
3. We now load the image in the component as a blob and stores it there. Until now the image was loaded by the img-tag in the browser and again by exif-js. However we can serve both from the component.