### PR TITLE
🩹 Lazy load attachment pdf iframe

### DIFF
--- a/froide/foirequest/templates/foirequest/attachment/show.html
+++ b/froide/foirequest/templates/foirequest/attachment/show.html
@@ -60,7 +60,7 @@
 {% if attachment.can_embed %}
   {% if attachment.is_pdf %}
     <div class="container-sm-full d-none d-md-block">
-      <iframe src="{{ attachment_url }}" frameborder="0" style="width: 100%; height: 90vh; border: 0;">
+      <iframe src="{{ attachment_url }}" frameborder="0" style="width: 100%; height: 90vh; border: 0;" loading="lazy">
       </iframe>
     </div>
     <div class="container d-block d-md-none text-center">


### PR DESCRIPTION
This prevents smartphones where we don't show the iframe from loading the pdf (saving bandwidth) and fixes the file being downloaded on iphones in lockdown mode.
