### PR TITLE
Add admin action and task to unzip FoiAttachment

### DIFF
--- a/froide/foirequest/admin.py
+++ b/froide/foirequest/admin.py
@@ -756,6 +756,7 @@ class FoiAttachmentAdmin(admin.ModelAdmin):
         "convert",
         "ocr_attachment",
         "make_document",
+        "unpack_zipfile",
     ]
 
     def get_queryset(self, request):
@@ -823,6 +824,13 @@ class FoiAttachmentAdmin(admin.ModelAdmin):
 
         for att in queryset:
             ocr_pdf_attachment(att)
+
+    @admin.action(description=_("Unpack ZIP file"))
+    def unpack_zipfile(self, request, queryset):
+        from .tasks import unpack_zipfile_attachment_task
+
+        for att in queryset:
+            unpack_zipfile_attachment_task.delay(att.id)
 
 
 @admin.register(FoiEvent)

--- a/froide/foirequest/tasks.py
+++ b/froide/foirequest/tasks.py
@@ -386,3 +386,17 @@ def move_upload_to_attachment(att_id, upload_id):
 
     if att.can_convert_to_pdf():
         convert_attachment_task.delay(att.id)
+
+
+@celery_app.task(
+    name="froide.foirequest.tasks.unpack_zipfile_attachment_task", time_limit=360
+)
+def unpack_zipfile_attachment_task(instance_id):
+    from .utils import unpack_zipfile_attachment
+
+    try:
+        att = FoiAttachment.objects.get(pk=instance_id)
+    except FoiAttachment.DoesNotExist:
+        return
+
+    unpack_zipfile_attachment(att)


### PR DESCRIPTION
It's a handy feature, but the following conceptual problems are unresolved:

- do new attachments keep track of their source attachment? The `converted` FK (points to converted file) and `is_converted` (is `True` on original) flag are intended to work the other way around. Changing the meaning just for this feature doesn't work well with other checks on `converted`. Maybe we need to refactor the meaning everywhere?
- do we trigger the unpacking automatically? I'm a bit afraid of recursive Zip files are zip bombs. Right now there is an admin action to trigger it manually and task is killed after three minutes.