### PR TITLE
Fix interpolation of query highlight

### DIFF
--- a/froide/document/feeds.py
+++ b/froide/document/feeds.py
@@ -72,8 +72,9 @@ class DocumentSearchFeed(Feed):
     @clean_feed_output
     def item_description(self, item):
         return format_html(
-            "<p>{description}</p><p>%s</p>" % item.query_highlight,
+            "<p>{description}</p><p>{highlight}</p>",
             description=item.document.description,
+            highlight=item.query_highlight,
         )
 
     def item_pubdate(self, item):


### PR DESCRIPTION
Query highlight is already marked safe, but could contain braces that interfere with string interpolation. Interpolating it directly via `format_html` works, because the function respects safe strings.