### PR TITLE
Move reason to bottom on public body form

### DIFF
--- a/froide/publicbody/forms.py
+++ b/froide/publicbody/forms.py
@@ -237,7 +237,6 @@ class PublicBodyProposalForm(forms.ModelForm):
     class Meta:
         model = PublicBody
         fields = (
-            "reason",
             "name",
             "other_names",
             "jurisdiction",
@@ -251,6 +250,7 @@ class PublicBodyProposalForm(forms.ModelForm):
             "regions",
             "file_index",
             "org_chart",
+            "reason",
         )
 
     def get_other_publicbodies(self):


### PR DESCRIPTION
To discourage people from filling in their proposed change in the reason field instead of the actual fields.