### PR TITLE
Increase minimum input for deadline input to 1 as 0 leads to 400 error

### DIFF
--- a/froide/foirequest/templates/foirequest/header/info-box.html
+++ b/froide/foirequest/templates/foirequest/header/info-box.html
@@ -121,7 +121,7 @@
                                 <div class="input-group input-group-sm mb-1">
                                     <input class="form-control"
                                            type="number"
-                                           min="0"
+                                           min="1"
                                            max="15"
                                            name="time"
                                            value="1">


### PR DESCRIPTION
Similar STRs to https://github.com/okfde/froide/issues/816, but if you enter `0` in that input box and press the button, you get a ~~404~~ 400 error. :upside_down_face:

![grafik](https://github.com/user-attachments/assets/3da8289c-849e-4a5e-9f86-82bc3c251af8)
