### PR TITLE
🚸 Do not strip leading / trailing spaces in foirequest body

### DIFF
--- a/froide/foirequest/forms/request.py
+++ b/froide/foirequest/forms/request.py
@@ -52,6 +52,7 @@ class RequestForm(JSONMixin, forms.Form):
                 "class": "form-control",
             }
         ),
+        strip=False,
     )
     full_text = forms.BooleanField(
         required=False,


### PR DESCRIPTION
This breaks leading indentation, e.g.

Please send me the following:
"  1. Document A
  2. Document B"
