### PR TITLE
🐛 Do not use submit-row class for object admin actions

### DIFF
--- a/froide/helper/static/admin/css/inline-actions.css
+++ b/froide/helper/static/admin/css/inline-actions.css
@@ -1,0 +1,15 @@
+.object-action-row {
+    padding: 12px 14px 12px;
+    margin: 0 0 20px;
+    background: var(--darkened-bg);
+    border: 1px solid var(--hairline-color);
+    border-radius: 4px;
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    align-items: baseline;
+}
+.object-action-row input, .object-action-row select {
+    height: 2.1875rem;
+    line-height: 0.9375rem;
+}

--- a/froide/helper/templates/admin/change_form.html
+++ b/froide/helper/templates/admin/change_form.html
@@ -1,11 +1,15 @@
 {% extends "admin/change_form.html" %}
-{% load i18n admin_urls admin_action_helper %}
+{% load i18n admin_urls admin_action_helper static %}
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="stylesheet" href="{% static "admin/css/inline-actions.css" %}">
+{% endblock %}
 {% block object-tools %}
     {{ block.super }}
     {% if not add %}
         {% render_admin_action_form adminform.model_admin original as action_form %}
         {% if action_form %}
-            <form class="submit-row"
+            <form class="object-action-row"
                   action="{% url opts|admin_urlname:'changelist' %}"
                   method="post">
                 {% csrf_token %}


### PR DESCRIPTION
django cms expects the first .submit-row to be the submit buttons and renders them on the edit modal
