### PR TITLE
💄 only show shadow on buttons when focused or active

### DIFF
--- a/frontend/styles/variables.scss
+++ b/frontend/styles/variables.scss
@@ -1,4 +1,4 @@
-@use "sass:map";
+@use 'sass:map';
 @import 'bootstrap/scss/functions';
 @import 'bootstrap/scss/mixins';
 
@@ -96,6 +96,7 @@ $container-max-widths: (
 
 // Typography
 $btn-font-weight: 600;
+$btn-box-shadow: 0 0 0 transparent; // shadow only when focused or active
 $badge-font-weight: 400;
 
 $link-decoration: none;


### PR DESCRIPTION
Does not affect focus states (i.e. focus ring on buttons).

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/eda7b9fd-a58b-4465-b938-4c7c9bdaec09) | ![image](https://github.com/user-attachments/assets/f1feb8f6-c3b2-4f4e-b5ce-65ccc8a990a3) |

Alternatively, we could set `$enable-shadows` to `false`, which would also alter form elements:

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/e916f213-f90d-404a-b0a8-6032aea3e4c4) | ![image](https://github.com/user-attachments/assets/2edc3266-f5b3-4e6f-8f03-fe80f3e09de3) |

Makes for a more modern, flat look. Fields should probably then have a background color though, since removing the inset shadows would decrease the very little contrast even further.