### PR TITLE
💄 don't override headings-color-dark, causes issues with utility classes

### DIFF
--- a/frontend/styles/variables.scss
+++ b/frontend/styles/variables.scss
@@ -58,7 +58,6 @@ $body-color-dark: $gray-400;
 
 $component-active-color: $white;
 $component-active-bg: $primary;
-$headings-color-dark: $white;
 $body-tertiary-color: rgba($body-color, 0.75);
 
 // spacing


### PR DESCRIPTION
the default of `inherit` is more adequate
