### PR TITLE
pdf-redaction: fix bad contrast in dark mode

### DIFF
--- a/frontend/javascript/components/redaction/pdf-redaction.vue
+++ b/frontend/javascript/components/redaction/pdf-redaction.vue
@@ -24,7 +24,7 @@
         </div>
       </div>
     </div>
-    <div v-if="working" class="row py-3 bg-light">
+    <div v-if="working" class="row py-3 text-bg-light">
       <div class="col">
         <div class="text-center">
           <h3 v-if="loading">


### PR DESCRIPTION
Quick fix for #921.
Proper fix would update the whole pdf redaction toolbar for dark mode -- what do you think, reviewers?
![grafik](https://github.com/user-attachments/assets/e3615535-306e-467f-9500-afc4c76e7d8a)
