### PR TITLE
Suggested changes based on my setup experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,43 @@
 
 [![Froide CI](https://github.com/okfde/froide/workflows/Froide%20CI/badge.svg)](https://github.com/okfde/froide/actions?query=workflow%3A%22Froide+CI%22)
 
-Froide is a Freedom Of Information Portal using Django 3.2 on Python 3.8+.
+Froide is a Freedom Of Information Portal using Django 4.2+ on Python 3.10+.
 
 It is used by the German and the Austrian FOI site, but it is fully
 internationalized and written in English.
 
 ## Development on Froide
 
-After clone, create a Python 3.8+ virtual environment and install dependencies:
+Required system tools:
+- [make](https://www.gnu.org/software/make/)
+- [uv](https://docs.astral.sh/uv/)
+- [Docker](https://www.docker.com/) or compatible containerisation tool
+- [pnpm](https://pnpm.io/)
+
+Required system libs:
+- libpoppler-cpp-dev
+
+After clone, create a Python 3.10+ virtual environment and install dependencies:
 
 ```
-python3 -m venv froide-env
-source froide-env/bin/activate
+# create and activate virtual envornment
+uv venv
+source .venv/bin/activate
 
-# Install dev dependencies
-pip install -r requirements-test.txt
+# install dependencies
+uv pip sync requirements-test.txt
+
+# build froide backend
+uv pip install -e . --no-deps
+
+# install UI test browser
+playwright install --with-deps chromium
+
+#install frontend dependencies
+pnpm install
+
+# build froide frontend
+pnpm run build
 
 # Install git pre-commit hook
 pre-commit install
@@ -80,9 +102,9 @@ Make sure to have pre-commit hooks registered (`pre-commit install`). For VSCode
 ### Upgrade dependencies
 
 ```
-# with pip-tools
-pip-compile -U requirements.in
-pip-compile -U requirements-test.in
+# with uv
+uv pip compile -o requirements.txt pyproject.toml -p 3.10
+uv pip compile -o requirements-test.txt --extra test pyproject.toml -p 3.10
 ```
 
 ## Docs

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Froide CI](https://github.com/okfde/froide/workflows/Froide%20CI/badge.svg)](https://github.com/okfde/froide/actions?query=workflow%3A%22Froide+CI%22)
 
-Froide is a Freedom Of Information Portal using Django 4.2+ on Python 3.10+.
+Froide is a Freedom Of Information Portal using Django 4.2+ on Python 3.12+.
 
 It is used by the German and the Austrian FOI site, but it is fully
 internationalized and written in English.
@@ -10,15 +10,23 @@ internationalized and written in English.
 ## Development on Froide
 
 Required system tools:
+
+- [Python 3.12+](https://www.python.org)
+- [Node.js 22+](https://nodejs.org)
+- [Docker](https://www.docker.com/) or compatible containerisation tool
 - [make](https://www.gnu.org/software/make/)
 - [uv](https://docs.astral.sh/uv/)
-- [Docker](https://www.docker.com/) or compatible containerisation tool
 - [pnpm](https://pnpm.io/)
+- [pre-commit](https://pre-commit.com)
 
-Required system libs:
-- libpoppler-cpp-dev
+Required system libraries:
 
-After clone, create a Python 3.10+ virtual environment and install dependencies:
+- [Poppler](https://poppler.freedesktop.org)
+- [GDAL](https://gdal.org)
+- cmake
+- pkg-config
+
+After clone, create a Python virtual environment and install dependencies:
 
 ```
 # create and activate virtual envornment
@@ -28,23 +36,23 @@ source .venv/bin/activate
 # install dependencies
 uv pip sync requirements-test.txt
 
+# Install git pre-commit hook
+pre-commit install
+
 # build froide backend
 uv pip install -e . --no-deps
 
-# install UI test browser
-playwright install --with-deps chromium
-
-# install node 20
-pnpm env use --global 20
-
-#install frontend dependencies
+# install frontend dependencies
 pnpm install
+
+# install UI test browser (optional)
+playwright install --with-deps chromium
 
 # build froide frontend
 pnpm run build
 
-# Install git pre-commit hook
-pre-commit install
+# or run the frontend devserver
+pnpm run dev
 ```
 
 ### Start services

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ uv pip install -e . --no-deps
 # install UI test browser
 playwright install --with-deps chromium
 
+# install node 20
+pnpm env use --global 20
+
 #install frontend dependencies
 pnpm install
 

--- a/README.md
+++ b/README.md
@@ -102,9 +102,7 @@ Make sure to have pre-commit hooks registered (`pre-commit install`). For VSCode
 ### Upgrade dependencies
 
 ```
-# with uv
-uv pip compile -o requirements.txt pyproject.toml -p 3.10
-uv pip compile -o requirements-test.txt --extra test pyproject.toml -p 3.10
+make requirements
 ```
 
 ## Docs

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -2,7 +2,7 @@
 About
 =====
 
-Froide is a Freedom of Information portal software written in Python with Django 1.11.
+Froide is a Freedom of Information portal software written in Python with Django.
 
 
 Development Goals

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,10 @@ description = "German Freedom of Information Portal"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Framework :: Django",
-  "Intended Audience :: Developers",
+  "Intended Audience :: Freedom of Information portal operators",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.10",
   "Topic :: Utilities",
 ]
 version = "5.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,10 @@ description = "German Freedom of Information Portal"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Framework :: Django",
-  "Intended Audience :: Freedom of Information portal operators",
+  "Intended Audience :: Developers",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Utilities",
 ]
 version = "5.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ test = [
   "pytest-django",
   "pytest-factoryboy",
   "pytest-playwright",
+  "ruff",
   "tblib",
   "text-unidecode",
   "time-machine",

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -411,6 +411,8 @@ rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
+ruff==0.9.3
+    # via froide (pyproject.toml)
 setuptools==74.1.2
     # via geoip2
 six==1.16.0


### PR DESCRIPTION
Hi

I try myself at the froide development setup right now.

While doing this, I try to improve the documentation.

Proposed changes so far:
- changed pyproject.toml classifiers
  because they puzzled me
- added ruff as test dependency
  because this allows me to avoid a system wide installation of ruff, which is needed for `make test`
- updated readme setup description, based on what the 'Froide CI' Github Job does
  because it was outdated and incomplete
- added sections about required system tools and libs
  because its tedious to find out one after another
- updated readme 'Update dependencies' using the make target
- removed a version reference from docs/about.rst
  it was outdated and it would only get outdated again

`pnpm install` and `pnpm run build` failed at the exifeader postinstall script until I also installed node 20 and npm.
Any ideas how to get by only with @pnpm/exe ?

After running the manage.py setup steps:
- visiting http://127.0.0.1:8000/ throws 'Please build frontend or run frontend dev server'
- ~~`make test` failed on 31 tests. See [test-summary.txt](https://github.com/user-attachments/files/18580403/test-summary.txt)~~
- after running `pytest --create-db` once, `make test` runs green.
  Since `pytest --create-db` needs to run after each database schema change (see [pytest-django docs: Example work flow with --reuse-db and --create-db](https://pytest-django.readthedocs.io/en/latest/database.html#example-work-flow-with-reuse-db-and-create-db)), this could become another make target.

Of all the system dependencies that are installed in 'Froide CI', I only installed 'libpoppler-cpp-dev' so far.

I propose to add a make target 'setup' and reference it from the readme. I think this would be less likely to become outdated.

I also plan to update the documentation. First of all docs/development.rst which seems to be completely outdated.

Please give feedback if this is helpful to you and give pointers what else is important for development setup.