### PR TITLE
Add decrypt PDF API endpoint, add decryption to approve process

### DIFF
--- a/froide/foirequest/serializers.py
+++ b/froide/foirequest/serializers.py
@@ -359,6 +359,11 @@ class ImageAttachmentConverterSerializer(serializers.Serializer):
     message = FoiMessageRelatedField()
 
 
+class DecryptAttachmentSerializer(serializers.Serializer):
+    password = serializers.CharField(required=True)
+    approved = serializers.BooleanField(default=False, required=False)
+
+
 def optimize_message_queryset(request, qs):
     atts = get_read_foiattachment_queryset(
         request, queryset=FoiAttachment.objects.filter(belongs_to__in=qs)

--- a/froide/foirequest/templates/foirequest/redact.html
+++ b/froide/foirequest/templates/foirequest/redact.html
@@ -22,9 +22,7 @@
         <form id="redaction-form" method="post" style="display:none">
             {% csrf_token %}
         </form>
-        <pdf-redaction id="redact" pdf-path="{{ attachment_url }}" attachment-url="{{ attachment.get_anchor_url }}" :redact-regex="{{ foirequest.get_redaction_regexes }}"
-        {% if not attachment.redacted and not attachment.is_redacted %}can-publish="true"{% endif %}
-        :config="{{ config }}" :bottom-toolbar="true">
+        <pdf-redaction id="redact" pdf-path="{{ attachment_url }}" attachment-url="{{ attachment.get_anchor_url }}" :redact-regex="{{ foirequest.get_redaction_regexes }}" :config="{{ config }}" :bottom-toolbar="true">
         <div class="text-center">
             <h3>{% trans "Redaction tool is loading..." %}</h3>
             <div class="spinner-border" role="status">

--- a/froide/foirequest/tests/test_api_attachment.py
+++ b/froide/foirequest/tests/test_api_attachment.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 
 import pytest
 
+from froide.foirequest.models import FoiAttachment
 from froide.foirequest.models.message import MessageKind
 from froide.foirequest.tests import factories
 from froide.upload.factories import UploadFactory
@@ -205,3 +206,95 @@ def test_convert_attachment(client: Client, user):
         content_type="application/json",
     )
     assert response.status_code == 404
+
+
+@pytest.mark.django_db(transaction=True)
+def test_decrypt_attachment(client: Client, user, monkeypatch):
+    request = factories.FoiRequestFactory.create(user=user)
+    message = factories.FoiMessageFactory.create(request=request, kind=MessageKind.POST)
+
+    encrypted = factories.FoiAttachmentFactory.create(
+        belongs_to=message,
+        filetype="application/pdf",
+    )
+
+    data = {
+        "bad": "wrong",
+        "appoved": True,
+    }
+    url = reverse("api:attachment-decrypt-pdf", kwargs={"pk": encrypted.pk})
+
+    # needs to be logged in
+    response = client.post(
+        url,
+        data=data,
+        content_type="application/json",
+    )
+    assert response.status_code == 401
+
+    # wrong user
+    other_user = factories.UserFactory.create()
+    assert client.login(email=other_user.email, password="froide")
+    response = client.post(
+        url,
+        data=data,
+        content_type="application/json",
+    )
+    assert response.status_code == 403
+
+    # bad data
+    assert client.login(email=user.email, password="froide")
+    response = client.post(
+        url,
+        data=data,
+        content_type="application/json",
+    )
+    assert response.status_code == 400
+
+    def mock_decrypt(path, password):
+        if password == "test":
+            return b"1"
+        return None
+
+    import filingcabinet.pdf_utils
+
+    monkeypatch.setattr(filingcabinet.pdf_utils, "decrypt_pdf", mock_decrypt)
+
+    # wrong password
+    data = {
+        "password": "wrong",
+        "approved": True,
+    }
+    assert client.login(email=user.email, password="froide")
+    response = client.post(
+        url,
+        data=data,
+        content_type="application/json",
+    )
+    # Attachment gets created but in failed decryption task deleted
+    assert response.status_code == 201
+    result = response.json()
+    assert not FoiAttachment.objects.filter(id=result["id"]).exists()
+
+    # everything good
+    data["password"] = "test"
+    assert client.login(email=user.email, password="froide")
+    response = client.post(
+        url,
+        data=data,
+        content_type="application/json",
+    )
+    assert response.status_code == 201
+    result = response.json()
+
+    assert result["name"] == "file-0-decrypted.pdf"
+    assert result["filetype"] == "application/pdf"
+    assert result["is_converted"] is True
+
+    decrypted = FoiAttachment.objects.get(id=result["id"])
+    assert decrypted.belongs_to == message
+    assert decrypted.approved
+    assert decrypted.is_converted
+
+    encrypted.refresh_from_db()
+    assert encrypted.converted_id == decrypted.id

--- a/froide/foirequest/views/attachment.py
+++ b/froide/foirequest/views/attachment.py
@@ -78,6 +78,16 @@ def approve_attachment(request, foirequest, attachment_id):
     # hard guard against publishing of non publishable requests
     if not foirequest.not_publishable:
         att.approve_and_save()
+        if att.redacted:
+            # if there are redacted versions, delete them
+            # as we are approving the original
+            redacted = att.redacted
+            redacted.attachment_deleted.send(
+                sender=redacted,
+                user=request.user,
+            )
+            redacted.remove_file_and_delete()
+
         att.attachment_approved.send(
             sender=att,
             user=request.user,

--- a/froide/foirequest/views/attachment.py
+++ b/froide/foirequest/views/attachment.py
@@ -15,6 +15,7 @@ from django.views.generic import DetailView
 
 from crossdomainmedia import CrossDomainMediaMixin
 
+from froide.foirequest.utils import create_decrypted_attachment
 from froide.helper.auth import is_crew
 from froide.helper.utils import is_ajax, render_400, render_403
 
@@ -77,7 +78,6 @@ def approve_attachment(request, foirequest, attachment_id):
 
     # hard guard against publishing of non publishable requests
     if not foirequest.not_publishable:
-        att.approve_and_save()
         if att.redacted:
             # if there are redacted versions, delete them
             # as we are approving the original
@@ -88,6 +88,12 @@ def approve_attachment(request, foirequest, attachment_id):
             )
             redacted.remove_file_and_delete()
 
+        if att.is_pdf and request.POST.get("password") is not None:
+            att = create_decrypted_attachment(
+                att, request.POST["password"], approved=True
+            )
+        else:
+            att.approve_and_save()
         att.attachment_approved.send(
             sender=att,
             user=request.user,

--- a/froide/helper/redaction.py
+++ b/froide/helper/redaction.py
@@ -77,11 +77,7 @@ def try_redacting_file(pdf_file, outpath, instructions):
     tries = 0
     while True:
         try:
-            rewritten_pdf_file = rewrite_pdf(pdf_file, instructions)
-            if rewritten_pdf_file is None:
-                # Possibly encrypted with password, let's just try it anyway
-                rewritten_pdf_file = pdf_file
-            return _redact_file(rewritten_pdf_file, outpath, instructions)
+            return _redact_file(pdf_file, outpath, instructions)
         except PDFException as e:
             tries += 1
             if tries > 2:

--- a/frontend/javascript/components/postupload/post-upload.vue
+++ b/frontend/javascript/components/postupload/post-upload.vue
@@ -1203,7 +1203,7 @@ addEventListener('hashchange', () => {
             '/' + pdfRedactionCurrentDoc.id + '/'
           )
             " :hide-done-button="true" :bottom-toolbar="false" :no-redirect="true" :redact-regex="['teststraße\ 1']"
-          :can-publish="true" :config="config" @uploaded="pdfRedactionUploaded"
+          :config="config" @uploaded="pdfRedactionUploaded"
           @hasredactionsupdate="pdfRedactionCurrentHasRedactions = $event" ref="pdfRedaction">
           <!--
               <template #toolbar-right>

--- a/frontend/javascript/components/redaction/pdf-redaction.vue
+++ b/frontend/javascript/components/redaction/pdf-redaction.vue
@@ -186,19 +186,14 @@
         </div>
 
         <div
-          v-if="!hideDoneButton && (hasRedactions || hasPassword || (canPublish && !hasPassword))"
+          v-if="!hideDoneButton"
           class="btn-group mt-lg-0 py-2 mw-lg-50 mw-xl-25">
-          <button v-if="hasRedactions || hasPassword" class="btn btn-dark" @click="redact">
+          <button v-if="hasRedactions" class="btn btn-dark" @click="redact">
             <i class="fa fa-check me-2" />
-            <template v-if="hasRedactions">
               {{ i18n.redactAndPublish }}
-            </template>
-            <template v-else-if="hasPassword">
-              {{ i18n.removePasswordAndPublish }}
-            </template>
           </button>
           <form
-            v-if="canPublish && !hasPassword && !hasRedactions"
+            v-if="!hasRedactions"
             method="post"
             id="redaction-submit-form"
             :action="config.urls.publishUrl"
@@ -208,6 +203,7 @@
               name="csrfmiddlewaretoken"
               :value="csrfToken"
             />
+            <input v-if="hasPassword" type="hidden" name="password" :value="password" />
             <button
               class="btn btn-dark"
               type="submit"
@@ -319,8 +315,8 @@ import range from 'lodash.range'
 
 import { Modal } from 'bootstrap'
 
-import { bustCache, getData } from '../../lib/api.js'
 import { toRaw } from 'vue'
+import { bustCache, getData } from '../../lib/api.js'
 
 // 1000px are good enough to redact an A4 page with 10pt text
 const minRenderWidth = 1000
@@ -374,10 +370,6 @@ export default {
     redactRegex: {
       type: Array,
       default: () => []
-    },
-    canPublish: {
-      type: Boolean,
-      default: false
     },
     hideDoneButton: {
       type: Boolean,
@@ -724,7 +716,7 @@ export default {
       this.textOnly = !this.textDisabled
     },
     async redactOrApprove() {
-      if (this.hasRedactions || this.hasPassword) {
+      if (this.hasRedactions) {
         // .redact() handles autoApprove
         return this.redact()
       }


### PR DESCRIPTION
- PDF decryption got some utils and an API action on attachment (tests included)
- I removed the `canPublish` on `pdf-redaction`:
  - We don't have a concept of "publish" on attachment, only of approval. Publishing happens on the foirequest level.
  - Instead we should replace or remove redacted versions on redaction or approval, respectively.
- The approval view (non-API) now does decryption on PDFs when a password is provided. This means no-redaction encrypted PDFs don't need to go through the redaction process anymore.
