### PR TITLE
Introduce tests for redaction to make changes easier

### DIFF
--- a/froide/helper/redaction.py
+++ b/froide/helper/redaction.py
@@ -81,7 +81,11 @@ def try_redacting_file(pdf_file, outpath, instructions):
             if rewritten_pdf_file is None:
                 # Possibly encrypted with password, let's just try it anyway
                 rewritten_pdf_file = pdf_file
-            return _redact_file(rewritten_pdf_file, outpath, instructions)
+
+            output_filename = os.path.join(outpath, "final.pdf")
+            with open(output_filename, "wb") as output_file:
+                _redact_file(rewritten_pdf_file, output_file, instructions)
+            return output_filename
         except PDFException as e:
             tries += 1
             if tries > 2:
@@ -98,7 +102,7 @@ def try_redacting_file(pdf_file, outpath, instructions):
             pdf_file = next_pdf_file
 
 
-def _redact_file(pdf_file, outpath, instructions, tries=0):
+def _redact_file(pdf_file, output_file, instructions):
     dpi = 300
     load_invisible_font()
     output = PdfWriter()
@@ -149,11 +153,7 @@ def _redact_file(pdf_file, outpath, instructions, tries=0):
             raise PDFException(e, "rewrite") from None
 
         output.add_page(page)
-
-    output_filename = os.path.join(outpath, "final.pdf")
-    with open(output_filename, "wb") as f:
-        output.write(f)
-    return output_filename
+    output.write(output_file)
 
 
 def get_redacted_page(image_filename, instr, dpi):

--- a/froide/helper/tests/test_redaction.py
+++ b/froide/helper/tests/test_redaction.py
@@ -1,0 +1,42 @@
+import os
+from io import BytesIO
+from pathlib import Path
+from unittest import TestCase
+
+import pytest
+
+from froide.helper.redaction import _redact_file
+
+redaction_test_data_path = (
+    Path(os.path.dirname(os.path.realpath(__file__))) / "testdata" / "redaction"
+)
+hello_world_pdf_path = redaction_test_data_path / "minimal_hello_world.pdf"
+hello_world_pdf_redacted_path = (
+    redaction_test_data_path / "minimal_hello_world_redacted.pdf"
+)
+
+
+def get_file_content(file):
+    file.seek(0)
+    return file.read()
+
+
+class Test(TestCase):
+    def setUp(self):
+        self.input = hello_world_pdf_path.open("rb", buffering=0)
+        self.expected = hello_world_pdf_redacted_path.read_bytes()
+
+    def tearDown(self):
+        self.input.close()
+
+    @pytest.mark.asyncio(loop_scope="session")
+    def test__redact_file_empty_instructions(self):
+        in_memory_outfile = BytesIO()
+        empty_instructions = {"pages": [{"width": 1, "rects": []}]}
+
+        _redact_file(self.input, in_memory_outfile, empty_instructions)
+
+        self.assertEqual(
+            hello_world_pdf_redacted_path.read_bytes(),
+            get_file_content(in_memory_outfile),
+        )

--- a/froide/helper/tests/testdata/redaction/README.md
+++ b/froide/helper/tests/testdata/redaction/README.md
@@ -1,0 +1,7 @@
+# Minimal PDF
+
+## minimal_hello_world.pdf
+It's from https://brendanzagaeski.appspot.com/0004.html under MIT License.
+License: ./minimal_hello_world_license.txt
+
+Other redaction test pdf's in this folder are derived from it and share the license.

--- a/froide/helper/tests/testdata/redaction/minimal_hello_world.pdf
+++ b/froide/helper/tests/testdata/redaction/minimal_hello_world.pdf
@@ -1,0 +1,58 @@
+%PDF-1.1
+%¥±ë
+
+1 0 obj
+  << /Type /Catalog
+     /Pages 2 0 R
+  >>
+endobj
+
+2 0 obj
+  << /Type /Pages
+     /Kids [3 0 R]
+     /Count 1
+     /MediaBox [0 0 300 144]
+  >>
+endobj
+
+3 0 obj
+  <<  /Type /Page
+      /Parent 2 0 R
+      /Resources
+       << /Font
+           << /F1
+               << /Type /Font
+                  /Subtype /Type1
+                  /BaseFont /Times-Roman
+               >>
+           >>
+       >>
+      /Contents 4 0 R
+  >>
+endobj
+
+4 0 obj
+  << /Length 55 >>
+stream
+  BT
+    /F1 18 Tf
+    0 0 Td
+    (Hello World) Tj
+  ET
+endstream
+endobj
+
+xref
+0 5
+0000000000 65535 f 
+0000000018 00000 n 
+0000000077 00000 n 
+0000000178 00000 n 
+0000000457 00000 n 
+trailer
+  <<  /Root 1 0 R
+      /Size 5
+  >>
+startxref
+565
+%%EOF

--- a/froide/helper/tests/testdata/redaction/minimal_hello_world_license.txt
+++ b/froide/helper/tests/testdata/redaction/minimal_hello_world_license.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Brendan Zagaeski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/froide/helper/tests/testdata/redaction/minimal_hello_world_redacted.pdf
+++ b/froide/helper/tests/testdata/redaction/minimal_hello_world_redacted.pdf
@@ -1,0 +1,66 @@
+%PDF-1.3
+%‚„œ”
+1 0 obj
+<<
+/Type /Pages
+/Count 1
+/Kids [ 4 0 R ]
+>>
+endobj
+2 0 obj
+<<
+/Producer (pypdf)
+>>
+endobj
+3 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/Resources <<
+/Font <<
+/F1 <<
+/Type /Font
+/Subtype /Type1
+/BaseFont /Times-Roman
+>>
+>>
+>>
+/Contents 5 0 R
+/MediaBox [ 0 0 300 144 ]
+/Parent 1 0 R
+>>
+endobj
+5 0 obj
+<<
+/Length 55
+>>
+stream
+  BT
+    /F1 18 Tf
+    0 0 Td
+    (Hello World) Tj
+  ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000074 00000 n 
+0000000113 00000 n 
+0000000162 00000 n 
+0000000341 00000 n 
+trailer
+<<
+/Size 6
+/Root 3 0 R
+/Info 2 0 R
+>>
+startxref
+446
+%%EOF


### PR DESCRIPTION
In preparation to fix https://github.com/okfde/froide/issues/316 'PDFs get way too large when redacting', I propose to add tests for the redaction logic.
This allows to execute that logic without to run the full application, reducing the feedback time.

Step 1:
A first characterization test, testing the redaction behavior with empty instructions.

Please tell me if you approve this approach. 