### PR TITLE
fix: search button doesn't have an accessible name

### DIFF
--- a/froide/helper/templates/helper/search/multi_search.html
+++ b/froide/helper/templates/helper/search/multi_search.html
@@ -14,8 +14,8 @@
                placeholder="{% trans "Search term" %}" />
         <button type="submit"
                 class="btn btn-outline-primary text-nowrap{% if small %} btn-sm{% endif %}">
-            <i class="fa fa-search"></i>
-            <span class="d-md-none d-lg-inline" aria-hidden="true">{% trans "Search" %}</span>
+            <i class="fa fa-search" aria-hidden="true"></i>
+            <span class="d-md-none d-lg-inline">{% trans "Search" %}</span>
         </button>
     </div>
 </form>


### PR DESCRIPTION
The search button doesn't have an accessible name. That's because the `aria-hidden="true"`-HTML-attribute is set on the wrong HTML-tag, and should get moved to the preceding icon tag it's most likely meant for (compare to other places in the code like e.g. https://github.com/search?q=repo%3Aokfde%2Ffragdenstaat_de%20fa-search&type=code).