### PR TITLE
Resolve datetime deprecation warnings

### DIFF
--- a/froide/account/tests/test_account.py
+++ b/froide/account/tests/test_account.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 from urllib.parse import urlencode
 
@@ -128,7 +128,7 @@ def test_signup(world, client):
         "last_name": "Porst",
         "terms": "on",
         "user_email": "horst.porst",
-        "time": (datetime.utcnow() - timedelta(seconds=30)).timestamp(),
+        "time": (datetime.now(timezone.utc) - timedelta(seconds=30)).timestamp(),
     }
     client.login(email="info@fragdenstaat.de", password="froide")
     response = client.post(reverse("account-signup"), post)
@@ -182,7 +182,7 @@ def test_overlong_name_signup(world, client):
         "terms": "on",
         "user_email": "horst.porst@example.com",
         "address": "MyOwnPrivateStree 5\n31415 Pi-Ville",
-        "time": (datetime.utcnow() - timedelta(seconds=30)).timestamp(),
+        "time": (datetime.now(timezone.utc) - timedelta(seconds=30)).timestamp(),
     }
     client.logout()
     response = client.post(reverse("account-signup"), post)
@@ -289,7 +289,7 @@ def test_next_link_login(world, client):
     url = mes.get_absolute_url()
     enc_url = url.replace("#", "%23")  # FIXME: fake uri encode
     response = client.get(reverse("account-login") + "?next=%s" % enc_url)
-    # occurences in hidden inputs of login, signup and forgotten password
+    # occurrences in hidden inputs of login, signup and forgotten password
     assert response.content.decode("utf-8").count(url) == 2
     response = client.post(
         reverse("account-login"),

--- a/froide/helper/spam.py
+++ b/froide/helper/spam.py
@@ -2,7 +2,7 @@ import logging
 import os
 import re
 from dataclasses import asdict, dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional, Set
 
 from django import forms
@@ -193,7 +193,7 @@ class SpamProtectionMixin:
             )
         if self._should_include_timing():
             self.fields["time"] = forms.FloatField(
-                initial=datetime.utcnow().timestamp(), widget=forms.HiddenInput
+                initial=datetime.now(timezone.utc).timestamp(), widget=forms.HiddenInput
             )
 
     def _should_include_timing(self) -> bool:
@@ -232,7 +232,7 @@ class SpamProtectionMixin:
 
     def clean_time(self) -> str:
         value = self.cleaned_data["time"]
-        since = datetime.utcnow() - datetime.fromtimestamp(value)
+        since = datetime.now(timezone.utc) - datetime.fromtimestamp(value)
         if since < timedelta(seconds=5):
             raise forms.ValidationError(_("You filled this form out too quickly."))
         return value

--- a/froide/helper/spam.py
+++ b/froide/helper/spam.py
@@ -232,7 +232,9 @@ class SpamProtectionMixin:
 
     def clean_time(self) -> str:
         value = self.cleaned_data["time"]
-        since = datetime.now(timezone.utc).replace(tzinfo=None) - datetime.fromtimestamp(value)
+        since = datetime.now(timezone.utc).replace(
+            tzinfo=None
+        ) - datetime.fromtimestamp(value)
         if since < timedelta(seconds=5):
             raise forms.ValidationError(_("You filled this form out too quickly."))
         return value

--- a/froide/helper/spam.py
+++ b/froide/helper/spam.py
@@ -232,7 +232,7 @@ class SpamProtectionMixin:
 
     def clean_time(self) -> str:
         value = self.cleaned_data["time"]
-        since = datetime.now(timezone.utc) - datetime.fromtimestamp(value)
+        since = datetime.now(timezone.utc).replace(tzinfo=None) - datetime.fromtimestamp(value)
         if since < timedelta(seconds=5):
             raise forms.ValidationError(_("You filled this form out too quickly."))
         return value


### PR DESCRIPTION
# PR Summary
This small PR resolves the deprecation warnings on `datetime` in Python3.12+. You can find them in the [CI logs](https://github.com/okfde/froide/actions/runs/14664674665/job/41156572872#step:12:134):
```python
/home/runner/work/froide/froide/froide/account/tests/test_account.py:131: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).

/home/runner/work/froide/froide/froide/helper/spam.py:196: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
```