### PR TITLE
revert postupload failed images preview timing polling

### DIFF
--- a/frontend/javascript/components/docupload/attachment-icon-preview.vue
+++ b/frontend/javascript/components/docupload/attachment-icon-preview.vue
@@ -61,21 +61,6 @@ const iconTooltipTexts = computed(() => (needsRedaction.value && nudgeRedaction)
   ]
 )
 
-const maxRetries = 3
-
-let retries = maxRetries
-
-const retryLoad = (evt) => {
-  if (retries === 0) return
-  console.log('AttachmentIconPreview img failed to load, retrying', retries, evt)
-  retries--
-  // back off slightly, first retry wait 3s, last 10s
-  window.setTimeout(() => {
-    const sep = evt.target.src.indexOf('?') > 0 ? '&' : '?'
-    evt.target.src = evt.target.src + sep + 'retry=' + Date.now()
-  }, 10000 / (retries + 1))
-}
-
 </script>
 
 <template>
@@ -97,7 +82,6 @@ const retryLoad = (evt) => {
         :alt="i18n.preview"
         class="object-fit-contain shadow-sm"
         :style="{ maxWidth: size, maxHeight: size }"
-        @error="retryLoad"
         />
     </a>
     <a

--- a/frontend/javascript/components/docupload/image-page.vue
+++ b/frontend/javascript/components/docupload/image-page.vue
@@ -60,21 +60,6 @@ const progressPercentLabel = computed(() => {
   return '100%'
 })
 
-const maxRetries = 3
-
-let retries = maxRetries
-
-const retryLoad = (evt) => {
-  if (retries === 0) return
-  console.log('ImagePage img failed to load, retrying', retries, evt)
-  retries--
-  // back off slightly, first retry wait 3s, last 10s
-  window.setTimeout(() => {
-    const sep = evt.target.src.indexOf('?') > 0 ? '&' : '?'
-    evt.target.src = evt.target.src + sep + 'retry=' + Date.now()
-  }, 10000 / (retries + 1))
-}
-
 </script>
 
 <template>
@@ -88,7 +73,6 @@ const retryLoad = (evt) => {
         class="page-image d-block mw-100 mh-100 border"
         :src="page.file_url"
         :style="{ transform: `rotate(${totalRotate}deg)`}"
-        @error="retryLoad"
         />
       <div
         class="page-control page-control--number position-absolute bottom-0 mb-2 start-0 ms-1 text-bg-primary badge rounded-pill fw-bold lh-sm">


### PR DESCRIPTION
because websocket *did* work, got confused by doubled coded and local/staging/prod discrepancies