### PR TITLE
remove time limit for deletion of postal message drafts' attachments

### DIFF
--- a/froide/foirequest/models/attachment.py
+++ b/froide/foirequest/models/attachment.py
@@ -221,6 +221,8 @@ class FoiAttachment(models.Model):
             return False
         if not self.can_approve:
             return False
+        if self.belongs_to.is_draft:
+            return True
         now = timezone.now()
         return self.timestamp > (now - DELETE_TIMEFRAME)
 


### PR DESCRIPTION
following up a bug report on the forums, solution discussed with @pajowu 