### PR TITLE
fix pdf redaction w.r.t. page zoom, cross-browser inaccuracies, text mode

### DIFF
--- a/frontend/javascript/components/redaction/pdf-redaction.vue
+++ b/frontend/javascript/components/redaction/pdf-redaction.vue
@@ -3,6 +3,7 @@
     id="pdf-viewer"
     ref="top"
     class="pdf-redaction-tool container-xxl bg-dark-subtle d-flex flex-column"
+    :class="{ 'pdf-redaction-tool--debug': debug }"
   >
     <div v-if="hasPassword && ready" class="row">
       <div class="col">
@@ -149,6 +150,7 @@
 
         <div class="btn-group me-1 toolbar-modes py-2">
           <button
+            type="button"
             class="btn"
             :class="{
               'btn-outline-secondary': !textOnly,
@@ -161,6 +163,7 @@
             <small class="d-none d-xl-block">{{ i18n.toggleText }}</small>
           </button>
           <button
+            type="button"
             class="btn"
             :class="{
               'btn-outline-secondary': !textDisabled,
@@ -244,7 +247,10 @@
     <div class="row flex-grow-1">
       <div
         class="preview position-relative"
-        :class="{ ['preview--do-paint']: doPaint }"
+        :class="{
+          ['preview--do-paint']: doPaint,
+          ['preview--text-only']: textOnly
+        }"
         ref="containerWrapper"
         @wheel="mouseWheel"
         @pointerleave="pointerLeaveWrapper"
@@ -298,6 +304,7 @@
             <div
               :id="textLayerId"
               class="textLayer"
+              ref="textLayer"
               :class="{ textActive: textOnly, textDisabled: textDisabled }"
             />
           </div>
@@ -355,6 +362,9 @@ import { toRaw } from 'vue'
 
 import { useAttachments } from '../docupload/lib/attachments.js'
 const { fetchAttachment, approveAttachment } = useAttachments()
+
+// help with only Text mode debugging: show non-OCR original + highlight spans/divs
+const debug = false
 
 // 1000px are good enough to redact an A4 page with 10pt text
 const minRenderWidth = 1000
@@ -428,6 +438,7 @@ export default {
   emits: ['uploaded', 'hasredactionsupdate'],
   data() {
     return {
+      debug,
       doc: null,
       attachment: null,
       currentPage: null,
@@ -650,6 +661,8 @@ export default {
         let maxWidth = this.$refs.containerWrapper.offsetWidth
         // subtract the paddings (from bootstrap's row child),
         // fall back to the value calculated in default settings (like base font size)
+        // note: paddingLeft is the value set in CSS, so something like "12px",
+        //   unlike offsetWidth, still this value is consistent across page zoom
         maxWidth -=
           parseInt(
             window.getComputedStyle(this.$refs.containerWrapper)?.paddingLeft
@@ -667,9 +680,16 @@ export default {
         // - but would have to limit effective canvas size to prevent crashes
         renderDensityFactor = Math.max(minRenderWidth / window.innerWidth, 1.0)
 
-        const pageWidth = page.view[2]
-        const scaleFactor = (renderDensityFactor * maxWidth) / pageWidth
-        const viewport = page.getViewport({ scale: scaleFactor })
+        this.intrinsicPageWidth = page.view[2]
+        this.intrinsicPageHeight = page.view[3]
+
+        // redaction "rects'" coordinates are stored in "intrinsic PDF viewport = document pixels",
+        // and not in "browser/device pixels"
+        // (which are affected by page zoom, bootstrap viewports and rendering artifacts)
+        // so scaleFactor needs to be respected in many calculations in the component
+        // (to "(re)project" between the two views)
+        this.scaleFactor = (renderDensityFactor * maxWidth) / this.intrinsicPageWidth
+        const viewport = page.getViewport({ scale: this.scaleFactor })
 
         this.viewport = viewport
         const canvas = this.canvas
@@ -681,11 +701,11 @@ export default {
         const hPx = viewport.height / renderDensityFactor + 'px'
         console.log('PdfRedaction loadPage', {
           renderDensityFactor,
-          scaleFactor,
+          scaleFactor: this.scaleFactor,
           maxWidth,
           canvasViewportSize: [viewport.width, viewport.height],
           canvasCss: [wPx, hPx],
-          pageSize: [pageWidth, page.view[3]]
+          pageSize: [this.intrinsicPageWidth, this.intrinsicPageHeight]
         })
         canvas.style.width = wPx
         canvas.style.height = hPx
@@ -898,11 +918,9 @@ export default {
     serializePage(pageNumber) {
       const divs = this.textLayer.children
       const texts = Array.prototype.map.call(divs, (d) => {
-        const [dx, dy] = this.getDivPos(d)
-        const dw = d.offsetWidth
-        const dh = d.offsetHeight
+        const pos = this.getDivRect(d)
         return {
-          pos: [dx, dy, dw, dh],
+          pos,
           fontFamily: d.style.fontFamily,
           fontSize: d.style.fontSize,
           transform: d.style.transform,
@@ -910,9 +928,8 @@ export default {
         }
       })
       return {
-        width: this.viewport.width,
-        height: this.viewport.height,
-        scaleFactor: this.scaleFactor,
+        width: this.intrinsicPageWidth,
+        height: this.intrinsicPageHeight,
         pageNumber,
         rects: this.rectanglesPerPage[pageNumber],
         texts
@@ -955,6 +972,8 @@ export default {
       this.drawRectangles()
     },
     mouseDown(e, override) {
+      // throw out right/context-clicks etc.
+      if (e.button !== 0) return
       if (!this.doPaint && !override) {
         return
       }
@@ -981,6 +1000,10 @@ export default {
 
       const endDrag = this.endDrag
       this.endDrag = null
+      if (endDrag === null) {
+        console.log('Cancel malformed select')
+        return
+      }
       if (
         Math.abs(endDrag[0] - this.startDrag[0]) < 3 &&
         Math.abs(endDrag[1] - this.startDrag[1]) < 3
@@ -989,17 +1012,21 @@ export default {
         this.startDrag = null
         return
       }
-      const [x, y, w, h] = this.getRect(this.startDrag, endDrag)
+      // getRect is "device vs document pixel" agnostic;
+      // startDrag and endDrag are renderDensityFactor-aware, but not scaleFactor
+      let [x, y, w, h] = this.getRect(this.startDrag, endDrag)
       if (isNaN(parseFloat(x)) || isNaN(parseFloat(y))) {
         return
       }
+      x /= this.scaleFactor
+      y /= this.scaleFactor
+      w /= this.scaleFactor
+      h /= this.scaleFactor
 
       // find overlapping text and remove it completely
       const divs = this.textLayer.children
       const matches = Array.prototype.filter.call(divs, (d) => {
-        const [dx, dy] = this.getDivPos(d)
-        const dw = d.offsetWidth
-        const dh = d.offsetHeight
+        const [dx, dy, dw, dh] = this.getDivRect(d)
         return x < dx + dw && x + w > dx && y < dy + dh && y + h > dy
       })
       const texts = matches.map((d) => {
@@ -1208,21 +1235,30 @@ export default {
       }
       this.applyActionsOnPageLoad()
     },
-    drawRectangle(ctx, rect) {
+    drawRectangle(ctx, rect, doScale = false) {
       const [x, y, w, h] = rect
+      const f = doScale ? this.scaleFactor : 1
       ctx.fillStyle = '#000'
-      ctx.fillRect(x, y, w, h)
+      ctx.fillRect(x * f, y * f, w * f, h * f)
     },
     drawRectangles() {
-      const ctx = this.redactCanvas.getContext('2d')
+      const ctx = this.redactCanvas.getContext?.('2d')
+      if (!ctx) {
+        console.log('drawRectangel assume text mode, bail')
+        return
+      }
       ctx.clearRect(0, 0, this.canvas.width, this.canvas.height)
       if (this.rectanglesPerPage[this.currentPage] !== undefined) {
         this.rectanglesPerPage[this.currentPage].forEach((r) => {
-          this.drawRectangle(ctx, r)
+          this.drawRectangle(ctx, r, true)
         })
       }
       if (this.startDrag && this.endDrag) {
-        this.drawRectangle(ctx, this.getRect(this.startDrag, this.endDrag))
+        this.drawRectangle(
+          ctx,
+          this.getRect(this.startDrag, this.endDrag),
+          false
+        )
       }
     },
     applyActionsOnPageLoad() {
@@ -1338,11 +1374,22 @@ export default {
         this.message = this.i18n.autoRedacted
       }
     },
-    getDivPos(div) {
-      return [
-        parseInt(div.style.left.replace('px', '')),
-        parseInt(div.style.top.replace('px', ''))
-      ]
+    getDivRect(div) {
+      // more exact than clientLeft/offsetTop, which are ints
+      const parentWidth = parseFloat(this.textLayer.style.width.replace('px', ''))
+      const parentHeight = parseFloat(this.textLayer.style.height.replace('px', ''))
+      const divLeft = parseFloat(div.style.left.replace('px', ''))
+      const divTop = parseFloat(div.style.top.replace('px', ''))
+      const divWidth = div.offsetWidth
+      const divHeight = div.offsetHeight
+      const x = (divLeft / parentWidth) * this.intrinsicPageWidth
+      const y = (divTop / parentHeight) * this.intrinsicPageHeight
+      // alternative calculation, should be identical
+      // const x = divLeft * renderDensityFactor / this.scaleFactor
+      // const y = divTop * renderDensityFactor / this.scaleFactor
+      const w = divWidth * renderDensityFactor / this.scaleFactor
+      const h = divHeight * renderDensityFactor / this.scaleFactor
+      return [x, y, w, h]
     },
     redactText(div, start, text) {
       return this.redactRange(div, start, start + text.length)
@@ -1394,27 +1441,32 @@ export default {
       // approach without getBoundlingClientRect:
       // const scaleX = parseFloat(div.style.transform?.match(/scaleX\(([\d.]+)\)/)?.[1]) || 1.0
 
+      // we temporarily reset the text in its div to measure where the matched selected part begins
       div.textContent = text.substr(0, start)
-      const startWidth = div.getBoundingClientRect().width
-      // const startWidth = div.offsetWidth * scaleX
+      // const startWidth = div.offsetWidth * scaleX * renderDensityFactor / this.scaleFactor
+      const startWidth = div.getBoundingClientRect().width * renderDensityFactor / this.scaleFactor
 
+      // reset again to measure where matched part ends
       div.textContent = text.substr(0, start + match.length)
-      const endWidth = div.getBoundingClientRect().width
-      // const endWidth = div.offsetWidth * scaleX
+      // const endWidth = div.offsetWidth * scaleX * renderDensityFactor / this.scaleFactor
+      const endWidth = div.getBoundingClientRect().width * renderDensityFactor / this.scaleFactor
 
+      // and finally revert div's text
       div.textContent = text
 
-      const pos = this.getDivPos(div)
-      let x = pos[0]
-      const y = pos[1]
-      if (isNaN(parseFloat(x)) || isNaN(parseFloat(y))) {
-        return null
-      }
-      x += startWidth
       const width = endWidth - startWidth
 
-      const height = Math.min(div.offsetHeight * 1.2, div.offsetHeight + 10)
-      const padding = 2
+      const [x, y, /* w */, h] = this.getDivRect(div)
+
+      if (isNaN(x) || isNaN(y)) {
+        return null
+      }
+
+      // assume line height
+      const height = h * 1.2
+      // assuming DIN A4 at 210mm, let's have ~1mm of padding
+      const padding = this.intrinsicPageWidth / 200
+
       return {
         type: 'redact',
         texts: [
@@ -1425,7 +1477,12 @@ export default {
             textAfter: text.replace(match, replace)
           }
         ],
-        rects: [[x - padding, y, width + padding * 2, height]],
+        rects: [[
+          x + startWidth - padding,
+          y - padding,
+          width + padding * 2,
+          height + padding * 2,
+        ]],
         page: this.currentPage
       }
     },
@@ -1521,8 +1578,13 @@ export default {
   overflow: hidden;
 }
 
-.preview--do-paint[style],
-.preview--do-paint .redactContainer[style] {
+// user-select is usually disabled so it does not interfere with drag-to-pan.
+// In textOnly mode, we need to allow it, but only then, and only when doPaint
+// Otherwise, Firefox likes to select the whole div.redactContainer
+// when the dragging cursor crosses the middle of the div.
+// The whole div is then removed by selection.removeAllRanges()
+.preview--do-paint.preview--text-only[style],
+.preview--do-paint.preview--text-only .redactContainer[style] {
   user-select: text !important;
 }
 
@@ -1585,4 +1647,21 @@ export default {
   // reduces jitter when variable-width numbers change
   font-variant-numeric: tabular-nums;
 }
+
+.pdf-redaction-tool--debug {
+  // for onlyText show non-OCR original + highlight spans/divs on top
+
+  .textLayer[style] {
+    background: rgba(255, 255, 255, 0.2) !important;
+  }
+
+  .textLayer :deep(span) {
+    outline: 1px solid red;
+  }
+
+  canvas.redactLayer {
+    display: block !important;
+  }
+}
+
 </style>


### PR DESCRIPTION
Essentially the infamous last 20% to "mobile-ready pdf redaction" including legacy textOnly mode bugs.

I would appreciate a quick scan of code quality, if possible :)

- clean up "document pixel" vs "device pixel" spaces, respect scaleFactor/renderDensity everywhere, especially in textOnly mode
- this fixes page zoom related padding/margin rounding errors accumulating in Chrom*
- extend padding, relativize line-height calculation the absolute values / magic numbers make even less sense now
- fix weird behaviors, like buttons suddenly submitting, in spite of @click.stop
- fix drag-vs-select behavior in firefox
- better handle right/context clicks
- introduce a debug mode
- add some verbose comments