### PR TITLE
🐛 Fix public body proposal acceptance prefill

### DIFF
--- a/froide/publicbody/templates/publicbody/snippets/publicbody_proposals.html
+++ b/froide/publicbody/templates/publicbody/snippets/publicbody_proposals.html
@@ -67,7 +67,7 @@
                 <tr>
                     <td>
                         <div class="form-check float-end">
-                            <input class="form-check-input"
+                            <input class="form-check-input proposal"
                                    type="radio"
                                    id="proposal_id"
                                    name="proposal_id"
@@ -79,7 +79,7 @@
                     {% for proposal in proposals %}
                         <td>
                             <div class="form-check">
-                                <input class="form-check-input"
+                                <input class="form-check-input proposal"
                                        type="radio"
                                        name="proposal_id"
                                        id="proposal_id-{{ proposal.obj.id }}"


### PR DESCRIPTION
The JS that applies proposal values binds to elements with class `proposal`. Radios lost this class, so fields were not prefilled and HTML5 `required` blocked submit before the backend could handle proposal_id. This restores the class on both radios.