### PR TITLE
🔧 Add pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = froide.settings
+DJANGO_CONFIGURATION = Test
+
+filterwarnings =
+    ignore::DeprecationWarning:(?!froide).*
+    ignore::PendingDeprecationWarning:(?!froide)*


### PR DESCRIPTION
Suppresses deprecation warnings from third-party libraries when running tests with pytest