### PR TITLE
✨ Add filter to show all project requests in search views

### DIFF
--- a/froide/foirequest/documents.py
+++ b/froide/foirequest/documents.py
@@ -59,6 +59,8 @@ class FoiRequestDocument(Document):
     team = fields.IntegerField(attr="team_id")
 
     public = fields.BooleanField()
+    project = fields.IntegerField(attr="project_id")
+    project_order = fields.IntegerField()
 
     class Django:
         model = FoiRequest

--- a/froide/foirequest/filters.py
+++ b/froide/foirequest/filters.py
@@ -263,6 +263,19 @@ class BaseFoiRequestFilterSet(BaseSearchFilterSet):
         widget=BootstrapSelect,
         method="add_sort",
     )
+    hide_project_duplicates = django_filters.BooleanFilter(
+        label=_("Hide duplicate requests"),
+        method="filter_hide_project_duplicates",
+        widget=forms.CheckboxInput(
+            attrs={
+                "class": "form-check-input",
+                "role": "switch",
+            }
+        ),
+        help_text=_(
+            "When the same request is sent to many public bodies at once, only the first is shown."
+        ),
+    )
 
     class Meta:
         model = FoiRequest
@@ -347,6 +360,16 @@ class BaseFoiRequestFilterSet(BaseSearchFilterSet):
     def add_sort(self, qs, name, value):
         if value:
             return qs.add_sort("%s_message" % value)
+        return qs
+
+    def filter_hide_project_duplicates(self, qs, name, value):
+        if value:
+            return self.apply_filter(
+                qs,
+                name,
+                Q("bool", must_not={"exists": {"field": "project"}})
+                | Q("term", project_order=0),
+            )
         return qs
 
 

--- a/froide/foirequest/models/request.py
+++ b/froide/foirequest/models/request.py
@@ -111,15 +111,6 @@ class PublishedFoiRequestManager(CurrentSiteManager):
     def by_last_update(self):
         return self.get_queryset().order_by("-last_message")
 
-    def for_list_view(self):
-        return (
-            self.by_last_update()
-            .filter(
-                same_as__isnull=True,
-            )
-            .filter(models.Q(project__isnull=True) | models.Q(project_order=0))
-        )
-
     def get_resolution_count_by_public_body(self, obj):
         from ..filters import REVERSE_FILTER_DICT
 
@@ -648,12 +639,7 @@ class FoiRequest(models.Model):
         return self.visibility == self.VISIBILITY.VISIBLE_TO_PUBLIC
 
     def in_public_search_index(self):
-        return (
-            self.is_public()
-            and self.is_foi
-            and self.same_as_id is None
-            and (self.project_id is None or self.project_order == 0)
-        )
+        return self.is_public() and self.is_foi and self.same_as_id is None
 
     def get_redaction_regexes(self):
         from ..utils import get_foi_mail_domains

--- a/froide/foirequest/templates/foirequest/_request_search.html
+++ b/froide/foirequest/templates/foirequest/_request_search.html
@@ -45,8 +45,8 @@
         {{ form.user }}
         {{ form.organization }}
     </div>
-    {% if 'first' in show_filters or 'sort' in show_filters %}
-        <details {% if form.first.value.0 or form.first.value.1 or form.sort.value %}open{% endif %}>
+    {% if 'first' in show_filters or 'sort' in show_filters or 'hide_project_duplicates' in show_filters %}
+        <details {% if form.first.value.0 or form.first.value.1 or form.sort.value or form.hide_project_duplicates.value %}open{% endif %}>
             <summary>{% translate "More search options" %}</summary>
             <div class="row mt-2">
                 <div class="col-md-8">
@@ -66,6 +66,22 @@
                     {{ form.sort }}
                 {% endif %}
             </div>
+            {% if "hide_project_duplicates" in show_filters %}
+                <div class="row mt-2">
+                    <div class="col-md-8">
+                        <div class="form-check form-switch">
+                            {{ form.hide_project_duplicates }}
+                            <label class="form-check-label"
+                                   for="{{ form.hide_project_duplicates.id_for_label }}">
+                                {{ form.hide_project_duplicates.label }}
+                            </label>
+                            {% if form.hide_project_duplicates.help_text %}
+                                <div class="form-text">{{ form.hide_project_duplicates.help_text }}</div>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
         </details>
     {% endif %}
 </form>

--- a/froide/foirequest/tests/test_web.py
+++ b/froide/foirequest/tests/test_web.py
@@ -216,6 +216,48 @@ def test_list_no_identical(world, client):
 
 
 @pytest.mark.django_db
+@pytest.mark.xdist_group(name="sequential")
+def test_list_hide_project_duplicates_filter(world, client):
+    # Standalone request.
+    standalone_req = FoiRequest.published.first()
+
+    # Project with two requests.
+    project = factories.FoiProjectFactory.create(site=world)
+    project_req_a = factories.FoiRequestFactory.create(site=world)
+    project_req_b = factories.FoiRequestFactory.create(site=world)
+    project.add_requests(
+        FoiRequest.objects.filter(pk__in=[project_req_a.pk, project_req_b.pk])
+    )
+
+    # Make sure project requests are up-to-date and have the right order.
+    project_req_a.refresh_from_db()
+    project_req_b.refresh_from_db()
+    first_in_project, extra_in_project = sorted(
+        [project_req_a, project_req_b], key=lambda r: r.project_order
+    )
+    assert first_in_project.project_order == 0
+    assert extra_in_project.project_order == 1
+
+    factories.rebuild_index()
+
+    # Without the filter, every request shows up — including the project duplicate.
+    response = client.get(reverse("foirequest-list"))
+    assert response.status_code == 200
+    assertContains(response, standalone_req.title)
+    assertContains(response, first_in_project.title)
+    assertContains(response, extra_in_project.title)
+
+    # With the filter on, only the first request per project remains; standalone requests are unaffected.
+    response = client.get(
+        reverse("foirequest-list"), {"hide_project_duplicates": "true"}
+    )
+    assert response.status_code == 200
+    assertContains(response, standalone_req.title)
+    assertContains(response, first_in_project.title)
+    assertNotContains(response, extra_in_project.title)
+
+
+@pytest.mark.django_db
 def test_show_request(world, client):
     req = FoiRequest.objects.all()[0]
     response = client.get(

--- a/froide/foirequest/views/list_requests.py
+++ b/froide/foirequest/views/list_requests.py
@@ -19,7 +19,14 @@ NUM_RE = re.compile(r"^\[?\#?(\d+)\]?$")
 class BaseListRequestView(BaseSearchView):
     search_name = "foirequest"
     template_name = "foirequest/list.html"
-    show_filters = {"jurisdiction", "status", "category", "campaign", "sort"}
+    show_filters = {
+        "jurisdiction",
+        "status",
+        "category",
+        "campaign",
+        "sort",
+        "hide_project_duplicates",
+    }
     advanced_filters = {"jurisdiction", "category", "campaign"}
     has_facets = True
     facet_config = {

--- a/froide/locale/de/LC_MESSAGES/django.po
+++ b/froide/locale/de/LC_MESSAGES/django.po
@@ -3954,6 +3954,10 @@ msgstr "Hier können Sie eine weitere Nachricht an die Behörde senden."
 msgid "Hidden"
 msgstr "Versteckt"
 
+#: froide/foirequest/filters.py
+msgid "Hide duplicate requests"
+msgstr "Mehrfachanfragen ausblenden"
+
 #: froide/account/forms.py
 msgid "Hide my name from public view"
 msgstr "Zeige meinen Namen nicht öffentlich an"
@@ -8987,6 +8991,10 @@ msgstr "Welches Recht?"
 #: froide/foirequest/templates/foirequest/snippets/redaction_explanation.html
 msgid "What you need to redact"
 msgstr "Was Sie schwärzen sollten"
+
+#: froide/foirequest/filters.py
+msgid "When the same request is sent to many public bodies at once, only the first is shown."
+msgstr "Wenn dieselbe Anfrage gleichzeitig an mehrere Behörden gestellt wird, wird nur die erste angezeigt."
 
 #: froide/foirequest/views/message.py
 msgid "When was the letter sent?"

--- a/frontend/javascript/snippets/search.ts
+++ b/frontend/javascript/snippets/search.ts
@@ -39,12 +39,14 @@ export function initSearch(additionalBases: [string, string][] = []) {
 
   // auto-submit form helper
   // form.froide-auto-submit will submit the form when the value of any of its
-  // select inputs changes
+  // select inputs or checkbox inputs changes
   document
     .querySelectorAll<HTMLFormElement>('form.froide-auto-submit')
     .forEach((form) => {
-      form.querySelectorAll('select').forEach((select) => {
-        select.addEventListener('change', () => form.submit())
-      })
+      form
+        .querySelectorAll<HTMLElement>('select, input[type="checkbox"]')
+        .forEach((field) => {
+          field.addEventListener('change', () => form.submit())
+        })
     })
 }


### PR DESCRIPTION
This PR introduces a filter option that allows hiding duplicate requests from the same project in search results. The previous default was to show only the first request per project; the new default is to show all requests, with the option to hide duplicates via the filter.

Also updates the autosubmit logic to include checkbox inputs, so the page reloads automatically when a checkbox state changes. This worked locally at first but stopped at some point (trouble with pnpm). Please test on your end as well.

The position and layout of the filter are open for discussion.

The changes in this PR require a rebuild of the foirequest index.