### PR TITLE
prevent multiple make foirequest form submissions

### DIFF
--- a/froide/foirequest/views/make_request.py
+++ b/froide/foirequest/views/make_request.py
@@ -284,6 +284,7 @@ class MakeRequestView(FormView):
                     "Are you sure you want to discard your current selection?"
                 ),
                 "loadMore": _("load more..."),
+                "loading": _("Loading..."),
                 "next": _("next"),
                 "previous": _("previous"),
                 "choosePublicBody": _("Choose public body"),

--- a/froide/tests/live/test_request.py
+++ b/froide/tests/live/test_request.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 
 import pytest
 from playwright.async_api import Page, expect
+from playwright.async_api import TimeoutError as PlaywrightTimeoutError
 
 from froide.foirequest.models import FoiRequest, RequestDraft
 from froide.foirequest.tests import factories
@@ -240,6 +241,62 @@ async def test_make_request_logged_out_with_existing_account(
     assert req.title == req_title
     assert not req.public
     assert pb in req.publicbodies.all()
+
+
+@pytest.mark.django_db
+@pytest.mark.xdist_group(name="sequential")
+@pytest.mark.asyncio(loop_scope="session")
+async def test_make_request_submit_multiple_times(
+    page: Page, live_server, public_body_with_index, dummy_user
+):
+    count_before = FoiRequest.objects.filter(user=dummy_user).count()
+
+    await do_login(page, live_server)
+    assert dummy_user.is_authenticated
+    await go_to_make_request_url(page, live_server)
+    await page.locator("request-page .btn-primary >> nth=0").click()
+    pb = PublicBody.objects.all().first()
+    await page.locator(".search-public_bodies").fill(pb.name)
+    await page.locator(".search-public_bodies-submit").click()
+    buttons = page.locator(".search-results .search-result .btn")
+    await expect(buttons).to_have_count(1)
+    await page.locator(".search-results .search-result .btn >> nth=0").click()
+
+    await page.fill("[name=subject]", req_title)
+    await page.fill("[name=body]", req_body)
+    await page.locator("[name=confirm]").click()
+    await page.locator("#step_write_request .btn-primary").click()
+
+    await page.locator("#step_request_public .btn-primary").click()
+
+    # click submit multiple times
+    form = page.locator("form[name='make_request']")
+    submit_button = page.locator("#send-request-button")
+
+    await form.dispatch_event("submit")
+    await form.dispatch_event("submit")
+    await form.dispatch_event("submit")
+
+    try:
+        await submit_button.click(timeout=100)
+        await submit_button.click(timeout=100)
+        await submit_button.click(timeout=100)
+    except PlaywrightTimeoutError:
+        pass
+
+    await page.wait_for_url(f"**{reverse('foirequest-request_sent')}*")
+
+    req = FoiRequest.objects.filter(user=dummy_user).order_by("-id")[0]
+    assert req.title == req_title
+    assert req.description == req_body
+    assert req_body in req.messages[0].plaintext
+    assert req.public
+    assert req.public_body == pb
+    assert req.status == "awaiting_response"
+
+    count_after = FoiRequest.objects.filter(user=dummy_user).count()
+
+    assert count_before + 1 == count_after
 
 
 @pytest.mark.django_db

--- a/froide/tests/live/utils.py
+++ b/froide/tests/live/utils.py
@@ -27,11 +27,10 @@ async def go_to_request_page(page, live_server, foirequest):
 
 
 @pytest.mark.asyncio(loop_scope="session")
-async def do_login(page, live_server, navigate=True):
-    if navigate:
-        await page.goto(live_server.url + reverse("account-login"))
-        user = User.objects.get(username="dummy")
-        await page.fill("[name=username]", user.email)
-        await page.fill("[name=password]", "froide")
-        await page.locator('button.btn.btn-primary[type="submit"]').click()
-        await expect(page.locator("#navbaraccount-link")).to_have_count(1)
+async def do_login(page, live_server):
+    await page.goto(live_server.url + reverse("account-login"))
+    user = User.objects.get(username="dummy")
+    await page.fill("[name=username]", user.email)
+    await page.fill("[name=password]", "froide")
+    await page.locator('button.btn.btn-primary[type="submit"]').click()
+    await expect(page.locator("#navbaraccount-link")).to_have_count(1)

--- a/frontend/javascript/components/makerequest/request-page.vue
+++ b/frontend/javascript/components/makerequest/request-page.vue
@@ -18,7 +18,7 @@
       {{ this.stepperSteps[this.stepperStepCurrent]?.label }}
     </SimpleStepper>
 
-    <div class="container">
+    <div class="container position-relative">
       <div class="row">
         <div class="col">
           <!-- v-show="step === STEPS.PREVIEW_SUBMIT"
@@ -387,6 +387,7 @@
                   :hide-public="hidePublic"
                   :hide-publicbody-chooser="hidePublicbodyChooser"
                   :show-draft="showDraft"
+                  :submitting="submitting"
                   @submit="submit"
                   @savedraft="saveDraft"
                   @onlinehelp-click="onlineHelpShow($event)"
@@ -398,6 +399,18 @@
           </div>
         </div>
       </div>
+
+      <Transition name="fade">
+        <div
+          class="position-absolute top-0 bottom-0 start-0 end-0 d-flex align-items-center justify-content-center text-bg-body bg-opacity-90 fs-1"
+          aria-live="polite"
+          role="status"
+          v-if="submitting"
+        >
+          <i class="fa fa-spinner fa-pulse me-3" aria-hidden="true" />
+          {{ i18n.loading }}
+        </div>
+      </Transition>
     </div>
     <!-- /.container -->
     <OnlineHelp ref="onlineHelp" />
@@ -846,6 +859,8 @@ export default {
       this.submitting = true
     },
     submit() {
+      if (this.submitting) return
+
       this.fetchError = null
       this.submitting = true
       const form = document.forms.make_request
@@ -876,12 +891,11 @@ export default {
         .then((resp) => {
           // ...frontend will display/handle them
           this.fetchedForms = resp
+          this.submitting = false
         })
         .catch((e) => {
           console.error(e)
           this.fetchError = e.message || this.i18n.error
-        })
-        .finally(() => {
           this.submitting = false
         })
     },
@@ -1033,5 +1047,15 @@ legend {
     margin-left: auto;
     z-index: -1;
   }
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.5s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
 }
 </style>


### PR DESCRIPTION
I think handling this on the frontend is fine. Ideally, we have some kind of idempotency check (has the same user filed an FOI request with the same subject to the same public body in the last 5 minutes), but that seems difficult to implement without race conditions.
