### PR TITLE
Improve admin helper for choose object action

### DIFF
--- a/froide/helper/admin_utils.py
+++ b/froide/helper/admin_utils.py
@@ -67,16 +67,22 @@ def make_choose_object_action(
         else:
             form = Form()
 
+        select_across = request.POST.get("select_across", "0") == "1"
+        preview_queryset = None
+        if select_across:
+            preview_queryset = queryset[:50]
         opts = model_admin.model._meta
         context = {
             "opts": opts,
             "queryset": queryset,
+            "preview_queryset": preview_queryset,
             "media": model_admin.media,
             "action_checkbox_name": admin.helpers.ACTION_CHECKBOX_NAME,
             "form": form,
             "headline": label,
             "actionname": request.POST.get("action"),
             "applabel": opts.app_label,
+            "select_across": select_across,
         }
 
         # Display the confirmation page

--- a/froide/helper/forms.py
+++ b/froide/helper/forms.py
@@ -86,6 +86,8 @@ def get_fake_fk_form_class(
         queryset = model.objects.all()
 
     class ForeignKeyForm(forms.Form):
-        obj = forms.ModelChoiceField(queryset=queryset, widget=widget)
+        obj = forms.ModelChoiceField(
+            queryset=queryset, widget=widget, label=model._meta.verbose_name
+        )
 
     return ForeignKeyForm

--- a/froide/helper/templates/helper/admin/apply_action.html
+++ b/froide/helper/templates/helper/admin/apply_action.html
@@ -12,16 +12,26 @@
         <div>
             <p>{{ headline }}</p>
             {{ form.as_p }}
-            <ul>
-                {% for obj in queryset %}
-                    <li>
-                        {{ obj }}
-                        <input type="hidden"
-                               name="{{ action_checkbox_name }}"
-                               value="{{ obj.pk|unlocalize }}" />
-                    </li>
-                {% endfor %}
-            </ul>
+            {% if select_across %}
+                <input type="hidden" name="select_across" value="1" />
+                <p>
+                    {% blocktrans with count=queryset.count preview_count=preview_queryset.count %}You have selected {{ count }} objects, here is a preview of the first {{ preview_count }}:{% endblocktrans %}
+                </p>
+                <ul>
+                    {% for obj in preview_queryset %}<li>{{ obj }}</li>{% endfor %}
+                </ul>
+            {% else %}
+                <ul>
+                    {% for obj in queryset %}
+                        <li>
+                            {{ obj }}
+                            <input type="hidden"
+                                   name="{{ action_checkbox_name }}"
+                                   value="{{ obj.pk|unlocalize }}" />
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
             <input type="hidden" name="action" value="{{ actionname }}" />
             <input type="submit" value="{% trans "Execute" %}" />
         </div>

--- a/froide/helper/tests/test_admin_utils.py
+++ b/froide/helper/tests/test_admin_utils.py
@@ -85,13 +85,15 @@ class TestMakeChooseObjectAction:
 
         assert isinstance(response, TemplateResponse)
         assert response.template_name == "helper/admin/apply_action.html"
-        assert len(response.context_data) == 8
+        assert len(response.context_data) == 10
         assert response.context_data["opts"] == mock_model_admin.model._meta
         assert response.context_data["queryset"] == mock_queryset
         assert response.context_data["media"] == "mock_media"
         assert response.context_data["action_checkbox_name"] == "_selected_action"
         assert response.context_data["form"] == mock_form
         assert response.context_data["headline"] == "Test Action"
+        assert response.context_data["select_across"] is False
+        assert response.context_data["preview_queryset"] is None
         assert response.context_data["actionname"] == "Test Action"
         assert response.context_data["applabel"] == "test_app"
         mock_callback.assert_not_called()
@@ -113,12 +115,14 @@ class TestMakeChooseObjectAction:
 
         assert isinstance(response, TemplateResponse)
         assert response.template_name == "helper/admin/apply_action.html"
-        assert len(response.context_data) == 8
+        assert len(response.context_data) == 10
         assert response.context_data["opts"] == mock_model_admin.model._meta
         assert response.context_data["queryset"] == mock_queryset
         assert response.context_data["media"] == "mock_media"
         assert response.context_data["action_checkbox_name"] == "_selected_action"
         assert response.context_data["form"] == mock_form
+        assert response.context_data["select_across"] is False
+        assert response.context_data["preview_queryset"] is None
         assert response.context_data["headline"] == "Test Action"
         assert response.context_data["actionname"] == "Test Action"
         assert response.context_data["applabel"] == "test_app"


### PR DESCRIPTION
Can now be used better with select across with lots of objects.

Before it would have to POST IDs of all objects which could outgrow POST size limits.