### PR TITLE
Add accessibility snapshot tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,19 @@ Make sure the services are running.
 ```shell
 # Run all tests
 make test
-# Run only unit/integration tests
-make testci
-# Run only end-to-end tests
-make testui
+# Run only the end-to-end tests, which include the accessibility checks
+pytest froide/tests/live
+```
+
+### Accessibility tests
+
+The end-to-end tests check the pages they visit with [axe-core](https://github.com/dequelabs/axe-core). Findings are compared against the snapshots in `froide/tests/live/snapshots/`, so a test fails when a page gains a problem it didn't have before — existing findings are accepted debt.
+
+```shell
+# Record the current findings as the new baseline, then review the diff and commit
+pytest froide/tests/live --force-regen
+# Show the full axe report for every finding, recorded or not
+pytest froide/tests/live --a11y-strict
 ```
 
 ### Development tooling

--- a/froide/tests/live/snapshots/test_a11y/test_a11y_chromium_account_login.txt
+++ b/froide/tests/live/snapshots/test_a11y/test_a11y_chromium_account_login.txt
@@ -1,0 +1,2 @@
+violations:color-contrast
+violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_a11y/test_a11y_chromium_account_signup.txt
+++ b/froide/tests/live/snapshots/test_a11y/test_a11y_chromium_account_signup.txt
@@ -1,0 +1,3 @@
+incomplete:aria-valid-attr-value
+violations:color-contrast
+violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_a11y/test_a11y_chromium_foirequest_make_request.txt
+++ b/froide/tests/live/snapshots/test_a11y/test_a11y_chromium_foirequest_make_request.txt
@@ -1,0 +1,4 @@
+incomplete:color-contrast
+violations:color-contrast
+violations:landmark-unique
+violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_a11y/test_a11y_chromium_index.txt
+++ b/froide/tests/live/snapshots/test_a11y/test_a11y_chromium_index.txt
@@ -1,0 +1,3 @@
+violations:color-contrast
+violations:link-in-text-block
+violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_request/test_edit_request_boilerplate_chromium_step_write_request_full_text.txt
+++ b/froide/tests/live/snapshots/test_request/test_edit_request_boilerplate_chromium_step_write_request_full_text.txt
@@ -1,0 +1,4 @@
+incomplete:color-contrast
+violations:color-contrast
+violations:landmark-unique
+violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_request/test_make_logged_in_request_chromium.txt
+++ b/froide/tests/live/snapshots/test_request/test_make_logged_in_request_chromium.txt
@@ -1,0 +1,3 @@
+incomplete:aria-prohibited-attr
+violations:color-contrast
+violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_request/test_make_logged_in_request_too_many_chromium_alert.txt
+++ b/froide/tests/live/snapshots/test_request/test_make_logged_in_request_too_many_chromium_alert.txt
@@ -1,0 +1,1 @@
+violations:link-in-text-block

--- a/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_chromium_account_confirmed.txt
+++ b/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_chromium_account_confirmed.txt
@@ -1,0 +1,4 @@
+incomplete:aria-valid-attr-value
+violations:heading-order
+violations:link-in-text-block
+violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_chromium_account_new.txt
+++ b/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_chromium_account_new.txt
@@ -1,0 +1,1 @@
+violations:heading-order

--- a/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_chromium_step_create_account.txt
+++ b/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_chromium_step_create_account.txt
@@ -1,0 +1,4 @@
+incomplete:color-contrast
+violations:color-contrast
+violations:landmark-unique
+violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_chromium_step_login_create.txt
+++ b/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_chromium_step_login_create.txt
@@ -1,0 +1,4 @@
+incomplete:color-contrast
+violations:color-contrast
+violations:landmark-unique
+violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_chromium_step_preview_submit.txt
+++ b/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_chromium_step_preview_submit.txt
@@ -1,0 +1,5 @@
+incomplete:color-contrast
+violations:color-contrast
+violations:landmark-unique
+violations:link-in-text-block
+violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_chromium_step_request_public.txt
+++ b/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_chromium_step_request_public.txt
@@ -1,0 +1,4 @@
+incomplete:color-contrast
+violations:color-contrast
+violations:landmark-unique
+violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_chromium_step_select_publicbody.txt
+++ b/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_chromium_step_select_publicbody.txt
@@ -1,0 +1,4 @@
+incomplete:color-contrast
+violations:color-contrast
+violations:landmark-unique
+violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_chromium_step_write_request.txt
+++ b/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_chromium_step_write_request.txt
@@ -1,0 +1,4 @@
+incomplete:color-contrast
+violations:color-contrast
+violations:landmark-unique
+violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_to_public_body_chromium_step_write_request.txt
+++ b/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_to_public_body_chromium_step_write_request.txt
@@ -1,0 +1,4 @@
+incomplete:color-contrast
+violations:color-contrast
+violations:landmark-unique
+violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_request/test_set_status_chromium_unset_successful_detail.txt
+++ b/froide/tests/live/snapshots/test_request/test_set_status_chromium_unset_successful_detail.txt
@@ -1,0 +1,10 @@
+incomplete:aria-prohibited-attr
+incomplete:aria-valid-attr-value
+incomplete:color-contrast
+incomplete:link-in-text-block
+violations:aria-required-children
+violations:aria-required-parent
+violations:color-contrast
+violations:heading-order
+violations:listitem
+violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_request/test_set_status_chromium_unset_successful_edit_panel.txt
+++ b/froide/tests/live/snapshots/test_request/test_set_status_chromium_unset_successful_edit_panel.txt
@@ -1,0 +1,5 @@
+incomplete:aria-valid-attr-value
+incomplete:color-contrast
+violations:label
+violations:label-title-only
+violations:select-name

--- a/froide/tests/live/test_a11y.py
+++ b/froide/tests/live/test_a11y.py
@@ -1,0 +1,24 @@
+from django.urls import reverse
+
+import pytest
+from playwright.async_api import Page
+
+# (url name, reverse kwargs)
+PAGES = [
+    ("index", {}),
+    ("account-login", {}),
+    ("account-signup", {}),
+    ("foirequest-make_request", {}),
+]
+
+
+@pytest.mark.django_db
+@pytest.mark.xdist_group(name="sequential")
+@pytest.mark.asyncio(loop_scope="session")
+@pytest.mark.parametrize("url_name,kwargs", PAGES, ids=[entry[0] for entry in PAGES])
+async def test_a11y(page: Page, live_server, check_a11y, url_name: str, kwargs: dict):
+    response = await page.goto(live_server.url + reverse(url_name, kwargs=kwargs))
+    assert response is not None
+    assert response.status == 200, f"{url_name} returned HTTP {response.status}"
+
+    await check_a11y(page)

--- a/froide/tests/live/test_request.py
+++ b/froide/tests/live/test_request.py
@@ -25,7 +25,7 @@ req_body = "Documents describing & something..."
 @pytest.mark.xdist_group(name="sequential")
 @pytest.mark.asyncio(loop_scope="session")
 async def test_make_not_logged_in_request(
-    page: Page, live_server, public_body_with_index
+    page: Page, live_server, public_body_with_index, check_a11y
 ):
     pb = PublicBody.objects.all().first()
     await go_to_make_request_url(page, live_server)
@@ -34,8 +34,10 @@ async def test_make_not_logged_in_request(
     await page.locator(".search-public_bodies-submit").click()
     buttons = page.locator(".search-results .search-result .btn")
     await expect(buttons).to_have_count(1)
+    await check_a11y(page, suffix="step_select_publicbody")
     await page.locator(".search-results .search-result .btn >> nth=0").click()
 
+    await check_a11y(page, suffix="step_login_create")
     await page.locator("#step_login_create .btn-primary >> nth=0").click()
 
     await page.fill("[name=first_name]", "Peter")
@@ -45,15 +47,19 @@ async def test_make_not_logged_in_request(
     user_email = "peter.parker@example.com"
     await page.fill("[name=user_email]", user_email)
     await page.locator("[name=terms]").click()
+    await check_a11y(page, suffix="step_create_account")
     await page.locator("#step_create_account .btn-primary").click()
 
     await page.fill("[name=subject]", req_title)
     await page.fill("[name=body]", req_body)
     await page.locator("[name=confirm]").click()
+    await check_a11y(page, suffix="step_write_request")
     await page.locator("#step_write_request .btn-primary").click()
 
+    await check_a11y(page, suffix="step_request_public")
     await page.locator("#step_request_public .btn-primary").click()
 
+    await check_a11y(page, suffix="step_preview_submit")
     await page.locator("#send-request-button").click()
 
     await page.wait_for_url(f"**{reverse('account-new')}*")
@@ -67,6 +73,7 @@ async def test_make_not_logged_in_request(
     assert req.status == FoiRequest.STATUS.AWAITING_USER_CONFIRMATION
     assert req.description == req_body
     assert req_body in req.messages[0].plaintext
+    await check_a11y(page, suffix="account_new")
     message = mail.outbox[0]
     match = re.search(r"http://[^/]+(/.+)", message.body)
     activate_url = match.group(1)
@@ -78,17 +85,19 @@ async def test_make_not_logged_in_request(
     )
     req = FoiRequest.objects.get(user=new_user)
     assert req.status == "awaiting_response"
+    await check_a11y(page, suffix="account_confirmed")
 
 
 @pytest.mark.django_db
 @pytest.mark.xdist_group(name="sequential")
 @pytest.mark.asyncio(loop_scope="session")
 async def test_make_not_logged_in_request_to_public_body(
-    page: Page, live_server, world
+    page: Page, live_server, world, check_a11y
 ):
     pb = PublicBody.objects.all().first()
     assert pb
     await go_to_make_request_url(page, live_server, pb=pb)
+    await check_a11y(page, suffix="step_write_request")
 
     await page.fill("[name=subject]", req_title)
     await page.fill("[name=body]", req_body)
@@ -130,7 +139,7 @@ async def test_make_not_logged_in_request_to_public_body(
 @pytest.mark.xdist_group(name="sequential")
 @pytest.mark.asyncio(loop_scope="session")
 async def test_make_logged_in_request(
-    page, live_server, public_body_with_index, dummy_user
+    page, live_server, public_body_with_index, dummy_user, check_a11y
 ):
     await do_login(page, live_server)
     assert dummy_user.is_authenticated
@@ -162,6 +171,8 @@ async def test_make_logged_in_request(
     assert req.public_body == pb
     assert req.status == "awaiting_response"
 
+    await check_a11y(page)
+
 
 @pytest.mark.django_db
 @pytest.mark.xdist_group(name="sequential")
@@ -173,6 +184,7 @@ async def test_make_logged_in_request_too_many(
     foi_message_factory,
     world,
     request_throttle_settings,
+    check_a11y,
 ):
     dummy_user = User.objects.get(username="dummy")
     for _i in range(5):
@@ -197,6 +209,8 @@ async def test_make_logged_in_request_too_many(
 
     alert = page.locator(".alert-danger", has_text="exceeded your request limit")
     await expect(alert).to_be_visible()
+
+    await check_a11y(page, context=".alert-danger", suffix="alert")
 
 
 @pytest.mark.django_db
@@ -303,7 +317,7 @@ async def test_make_request_submit_multiple_times(
 @pytest.mark.xdist_group(name="sequential")
 @pytest.mark.asyncio(loop_scope="session")
 async def test_edit_request_boilerplate(
-    page: Page, live_server, public_body_with_index, dummy_user
+    page: Page, live_server, public_body_with_index, dummy_user, check_a11y
 ):
     pb = PublicBody.objects.all().first()
     await do_login(page, live_server)
@@ -318,6 +332,7 @@ async def test_edit_request_boilerplate(
     await page.get_by_role("textbox", name="Subject:").fill(req_title)
 
     await page.get_by_role("checkbox", name="Don't wrap in template").check()
+    await check_a11y(page, suffix="step_write_request_full_text")
 
     body = page.get_by_role("textbox", name="Request body:")
     initial_template = await body.input_value()
@@ -391,6 +406,7 @@ async def test_skip_search_similar(
 @pytest.mark.parametrize(
     "from_resolution, to_resolution",
     [("", "successful"), ("successful", "refused")],
+    ids=["unset_successful", "successful_refused"],
 )
 async def test_set_status(
     page,
@@ -400,6 +416,7 @@ async def test_set_status(
     foi_message_factory,
     from_resolution,
     to_resolution,
+    check_a11y,
 ):
     factories.rebuild_index()
     user = User.objects.get(username="dummy")
@@ -415,6 +432,12 @@ async def test_set_status(
     assert req.resolution == from_resolution
     await go_to_request_page(page, live_server, req)
     await expect(page.locator(".info-box__edit-panel > form")).not_to_be_visible()
+
+    # Both parameters render the same page and drive the panel below to the same
+    # state, so one of them is enough to snapshot.
+    if from_resolution == "":
+        await check_a11y(page, suffix="detail")
+
     await page.locator(".info-box__edit-button").click()
     await expect(page.locator(".info-box__edit-panel > form")).to_be_visible()
 
@@ -429,6 +452,9 @@ async def test_set_status(
 
     await page.locator('select[name="resolution"]').select_option("refused")
     await expect(page.locator("#id_refusal_reason")).to_be_visible()
+
+    if from_resolution == "":
+        await check_a11y(page, context=".info-box__edit-panel", suffix="edit_panel")
 
     await page.locator('select[name="resolution"]').select_option(to_resolution)
     await page.locator("#set-status-submit").click()

--- a/froide_a11y/__init__.py
+++ b/froide_a11y/__init__.py
@@ -1,0 +1,194 @@
+"""Accessibility checks for live (Playwright) tests.
+
+Registered as a pytest plugin through the `pytest11` entry point, so downstream
+projects get `check_a11y` from installing froide without any conftest wiring.
+"""
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from axe_playwright_python.base import AxeResults
+    from playwright.async_api import Page
+
+
+# Axe result types - findings marked as "incomplete" can imply severe bugs, so we include them.
+RESULT_TYPES = ["violations", "incomplete"]
+
+# Axe options, see https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter
+DEFAULT_AXE_OPTIONS: dict = {
+    "resultTypes": RESULT_TYPES,
+}
+
+
+@pytest.fixture
+def check_a11y(request, snapshot_regression, a11y_axe_options, pytestconfig):
+    """Assert that a page turns up nothing new since the last snapshot.
+
+    The snapshot is named after the test, `suffix` is appended to that. `context` and
+    `options` are passed to `axe.run()`, so the full axe-core API is available:
+    https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#api-name-axerun
+    """
+    try:
+        from axe_playwright_python.async_playwright import Axe
+    except ImportError:
+        Axe = None
+    if Axe is None:
+        pytest.fail(
+            "Accessibility checks need the axe-core bindings: install `froide[a11y]`.",
+            pytrace=False,
+        )
+
+    axe = Axe()
+    strict = pytestconfig.getoption("a11y_strict")
+
+    async def _check_a11y(
+        page: "Page",
+        *,
+        suffix: str | None = None,
+        context: str | list | dict | None = None,
+        options: dict | None = None,
+    ) -> None:
+        results = await axe.run(
+            page, context=context, options={**a11y_axe_options, **(options or {})}
+        )
+        snapshot_regression.check(
+            "\n".join(f"{finding}" for finding in _findings(results)),
+            extension=".txt",
+            basename=_basename(request.node.name, suffix),
+            check_fn=lambda obtained, expected: _compare(
+                obtained, expected, results, strict
+            ),
+        )
+
+    return _check_a11y
+
+
+def _compare(
+    obtained_path: Path,
+    expected_path: Path,
+    results: "AxeResults",
+    strict: bool,
+) -> None:
+    obtained = _read_findings(obtained_path)
+    # Under --a11y-strict nothing counts as recorded, so every finding is reported.
+    expected = set() if strict else _read_findings(expected_path)
+
+    appeared = sorted(obtained - expected)
+    resolved = sorted(expected - obtained)
+
+    if not appeared:
+        if not resolved:
+            return
+
+        raise AssertionError(
+            f"Accessibility findings gone: {', '.join(resolved)}\n"
+            "Re-record the snapshot with --force-regen, review the diff and commit."
+        )
+
+    label = "Accessibility findings" if strict else "New accessibility findings"
+    lines = [f"{label}: {', '.join(appeared)}"]
+
+    lines.extend(_report(results, finding) for finding in appeared)
+    if not strict:
+        lines.append(
+            "Fix the page. If this is accepted debt, record it with --force-regen, "
+            "review the diff and commit."
+        )
+
+    if resolved:
+        lines.append(f"\nAccessibility findings gone: {', '.join(resolved)}")
+        lines.append(
+            "Re-record with --force-regen once the new findings above are dealt "
+            "with - it records those as accepted debt too."
+        )
+
+    raise AssertionError("\n".join(lines))
+
+
+def _report(results: "AxeResults", finding: str) -> str:
+    """Render the axe report for one recorded finding."""
+    from axe_playwright_python.base import AxeResults
+
+    result_type, _, rule = finding.partition(":")
+
+    # `generate_report()` only reads `violations`, so hand it the array this
+    # finding came from.
+    return AxeResults({"violations": results.response[result_type]}).generate_report(
+        violation_id=rule
+    )
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup("froide")
+    group.addoption(
+        "--a11y-strict",
+        action="store_true",
+        default=False,
+        help=(
+            "Ignore the recorded snapshots and fail on every accessibility "
+            "finding, so the full axe report for each one is shown. The snapshots "
+            "are left untouched."
+        ),
+    )
+
+
+@pytest.fixture(scope="session")
+def a11y_axe_options() -> dict:
+    """Options passed to every `axe.run()`.
+
+    Override in a conftest to check a different set of rules.
+    """
+    return DEFAULT_AXE_OPTIONS
+
+
+@pytest.fixture(scope="session")
+def snapshot_dirname() -> str:
+    """Directory, relative to a test module, that regression data is kept in.
+
+    Override in a conftest to keep snapshots somewhere else.
+    """
+    return "snapshots"
+
+
+@pytest.fixture
+def snapshot_regression(
+    request: pytest.FixtureRequest, tmp_path: Path, snapshot_dirname: str
+):
+    """`file_regression`, with the recorded data nested one directory deeper.
+
+    pytest-regressions puts the directory of a module next to the module
+    itself, e.g. tests/test_module. This fixture adds a directory for
+    collecting all the snapshots, still organized in subdirectories per module,
+    e.g. tests/snapshots/test_module.
+    """
+    from pytest_datadir.plugin import LazyDataDir
+    from pytest_regressions.file_regression import FileRegressionFixture
+
+    module = Path(request.path)
+    datadir = module.parent / snapshot_dirname / module.stem
+    return FileRegressionFixture(LazyDataDir(datadir, tmp_path), datadir, request)
+
+
+def _findings(results: "AxeResults") -> list[str]:
+    """The `<result type>:<rule id>` label of every finding on the page."""
+    return sorted(
+        {
+            f"{result_type}:{finding['id']}"
+            for result_type in RESULT_TYPES
+            for finding in results.response[result_type]
+        }
+    )
+
+
+def _basename(node_name: str, suffix: str | None) -> str:
+    """The snapshot name: the test's own name plus an optional suffix."""
+    name = re.sub(r"[\W]", "_", node_name).rstrip("_")
+    return f"{name}_{suffix}" if suffix else name
+
+
+def _read_findings(path: Path) -> set[str]:
+    return {line.strip() for line in path.read_text().splitlines() if line.strip()}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,8 +64,16 @@ dependencies = [
   "dogtail @ git+https://github.com/okfde/dogtail.git@main",
 ]
 
+[project.optional-dependencies]
+a11y = [
+  "axe-playwright-python>=0.1.8",
+  "pytest-datadir>=1.8.0",
+  "pytest-regressions>=2.11.0",
+]
+
 [dependency-groups]
 dev = [
+  "froide[a11y]",
   "beautifulsoup4",
   "django-coverage-plugin",
   "django-extended-makemessages>=1.7.1",
@@ -95,6 +103,9 @@ dev = [
   "pytest-cov>=7.1.0",
   "django-stubs-ext<5.3",
 ]
+
+[project.entry-points.pytest11]
+froide_a11y = "froide_a11y"
 
 [build-system]
 requires = ["setuptools>=77.0.3", "wheel"]

--- a/uv.lock
+++ b/uv.lock
@@ -160,6 +160,18 @@ wheels = [
 ]
 
 [[package]]
+name = "axe-playwright-python"
+version = "0.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "playwright" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/3a/0ac4e97b92a3f8dc98f7dfb3b68c3e8d3811eda630000ccf4f7654e3498a/axe_playwright_python-0.1.8.tar.gz", hash = "sha256:97de160210fd5ce51e552d21d3b0a1cabb850235942737643ee3b9398de81a47", size = 194644, upload-time = "2026-07-24T20:11:06.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/c6/5fdb6d5d96653927b6a4763a4b7aaa9e468d4a6eda5048b7c2e158d17bc9/axe_playwright_python-0.1.8-py3-none-any.whl", hash = "sha256:fdd263c998388f1a8e67cad02677e612d946248bd44d163be5e8650ea31f95f8", size = 160681, upload-time = "2026-07-24T20:11:05.228Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1225,6 +1237,13 @@ dependencies = [
     { name = "websockets" },
 ]
 
+[package.optional-dependencies]
+a11y = [
+    { name = "axe-playwright-python" },
+    { name = "pytest-datadir" },
+    { name = "pytest-regressions" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "beautifulsoup4" },
@@ -1234,6 +1253,7 @@ dev = [
     { name = "django-stubs-ext" },
     { name = "factory-boy" },
     { name = "faker" },
+    { name = "froide", extra = ["a11y"] },
     { name = "greenlet" },
     { name = "monkeytype" },
     { name = "mypy" },
@@ -1259,6 +1279,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "axe-playwright-python", marker = "extra == 'a11y'", specifier = ">=0.1.8" },
     { name = "celery", specifier = ">=5.5.2" },
     { name = "channels", specifier = ">=4.2.2" },
     { name = "dj-database-url" },
@@ -1298,6 +1319,8 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.1" },
     { name = "pyisemail" },
     { name = "pypdf", specifier = ">=5.5.0" },
+    { name = "pytest-datadir", marker = "extra == 'a11y'", specifier = ">=1.8.0" },
+    { name = "pytest-regressions", marker = "extra == 'a11y'", specifier = ">=2.11.0" },
     { name = "python-magic" },
     { name = "python-mimeparse" },
     { name = "python-slugify" },
@@ -1307,6 +1330,7 @@ requires-dist = [
     { name = "weasyprint", specifier = ">=65.1" },
     { name = "websockets" },
 ]
+provides-extras = ["a11y"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1317,6 +1341,7 @@ dev = [
     { name = "django-stubs-ext", specifier = "<5.3" },
     { name = "factory-boy" },
     { name = "faker" },
+    { name = "froide", extras = ["a11y"] },
     { name = "greenlet", specifier = ">=3.1.1" },
     { name = "monkeytype" },
     { name = "mypy" },
@@ -2608,6 +2633,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-datadir"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/46/db060b291999ca048edd06d6fa9ee95945d088edc38b1172c59eeb46ec45/pytest_datadir-1.8.0.tar.gz", hash = "sha256:7a15faed76cebe87cc91941dd1920a9a38eba56a09c11e9ddf1434d28a0f78eb", size = 11848, upload-time = "2025-07-30T13:52:12.518Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/7a/33895863aec26ac3bb5068a73583f935680d6ab6af2a9567d409430c3ee1/pytest_datadir-1.8.0-py3-none-any.whl", hash = "sha256:5c677bc097d907ac71ca418109adc3abe34cf0bddfe6cf78aecfbabd96a15cf0", size = 6512, upload-time = "2025-07-30T13:52:11.525Z" },
+]
+
+[[package]]
 name = "pytest-django"
 version = "4.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2649,6 +2686,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/84/4f/8204515caeb84b1bbf295b36e8314e383213714c152d468cb4a0ba504f8a/pytest_playwright_asyncio-0.8.0.tar.gz", hash = "sha256:335edd83d1e80845632b0144f1f6d157ae30ef5c8dfa7d27ae1418bf0c74e8a5", size = 17193, upload-time = "2026-05-18T10:16:16.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/8e/1219ca47d8d42946395190c68666b88b8b23de9c2179d81da9cb6afd43cb/pytest_playwright_asyncio-0.8.0-py3-none-any.whl", hash = "sha256:628b8596be5248f90d5a00cdece13c466d61260c19b0d670d77384a994038f74", size = 17356, upload-time = "2026-05-18T10:16:19.545Z" },
+]
+
+[[package]]
+name = "pytest-regressions"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "pytest-datadir" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/0f/1d6b8cc851596be52c401af53fd0d844e72921b0b11866b88995673cd320/pytest_regressions-2.11.0.tar.gz", hash = "sha256:d4a86092f979eb25d2403c51b2b61039781c4c7c7a364a56b9fa838872a650f7", size = 117474, upload-time = "2026-05-25T12:09:01.796Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/61/fe772eda66bb8e2ee72da2937382aa4f803ca1e41092ca8d59953e96262c/pytest_regressions-2.11.0-py3-none-any.whl", hash = "sha256:fcb2bbcfb2fda256624d434c88cb1e4003667b7e078ee4084887cf839bbdf831", size = 25556, upload-time = "2026-05-25T12:09:00.292Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds automated a11y checks to the Playwright live tests, using [axe-core](https://github.com/dequelabs/axe-core) via [axe-playwright-python](https://github.com/pamelafox/axe-playwright-python).                                                                                                                                  

A new `check_a11y` fixture is added that can be used in live tests to run axe against the current page and compare the set of findings against a recorded snapshot. The fixture is added via a pytest plugin (`froide_a11y`) so downstream projects get `check_a11y` from installing froide, with no conftest wiring. The dependencies are an optional `a11y` extra, included in the dev dependencies so they are installed automatically for development.

The idea of snapshots is to capture the current state in terms of accessibility problems and burn them down step by step. New violations make the tests fail, as do disappearing violations - in which case snapshots have to be regenerated with `pytest --force-regen` to lock in the new behaviour. Existing findings are accepted debt and stay green.                                                                                                                                                                               

`pytest --a11y-strict` ignores the recorded snapshots and reports every finding with its full axe report. Useful for working through existing debt.
                                                                                                                                                                                                               
Snapshots are plain text files listing `<result type>:<rule id>` per line, e.g.:                                                                                                                                                                                                                                                                                                  
```
violations:color-contrast                                                                              
violations:page-has-heading-one
incomplete:aria-valid-attr-value
```                                                                                                                                                                               

In addition to the pytest plugin this PR adds some basic a11y tests for some important pages and introduces a11y checks to existing request flow tests.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
