### PR TITLE
Fix dangling and missing aria-describedby references in form fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The end-to-end tests check the pages they visit with [axe-core](https://github.c
 
 ```shell
 # Record the current findings as the new baseline, then review the diff and commit
+# (Recording stops at the first snapshot of a test, so repeat until the tests pass)
 pytest froide/tests/live --force-regen
 # Show the full axe report for every finding, recorded or not
 pytest froide/tests/live --a11y-strict

--- a/froide/conftest.py
+++ b/froide/conftest.py
@@ -64,6 +64,11 @@ def dummy_user():
     yield UserFactory(username="dummy")
 
 
+@pytest.fixture
+def dummy_staff_user():
+    yield UserFactory(username="dummy_staff", is_staff=True)
+
+
 @pytest.fixture()
 def request_throttle_settings(settings):
     froide_config = settings.FROIDE_CONFIG

--- a/froide/foirequest/templates/foirequest/_request_search.html
+++ b/froide/foirequest/templates/foirequest/_request_search.html
@@ -76,7 +76,10 @@
                                 {{ form.hide_project_duplicates.label }}
                             </label>
                             {% if form.hide_project_duplicates.help_text %}
-                                <div class="form-text">{{ form.hide_project_duplicates.help_text }}</div>
+                                <div class="form-text"
+                                     {% if form.hide_project_duplicates.auto_id %}id="{{ form.hide_project_duplicates.auto_id }}_helptext"{% endif %}>
+                                    {{ form.hide_project_duplicates.help_text }}
+                                </div>
                             {% endif %}
                         </div>
                     </div>

--- a/froide/helper/templates/helper/forms/bootstrap_field.html
+++ b/froide/helper/templates/helper/forms/bootstrap_field.html
@@ -1,6 +1,7 @@
 {% with classes=field.css_classes label=label|default:field.label help_text=help_text|default:field.help_text required=field.field.required %}
     {% if field_type == "radio" or is_checkboxmultiple %}
-        <fieldset class="row mb-3">
+        <fieldset class="row mb-3"
+                  {% if field.aria_describedby %}aria-describedby="{{ field.aria_describedby }}"{% endif %}>
             <legend class="fw-bold col-form-label col-md-4{% if required %} field-required{% endif %}">{{ label }}</legend>
             <div class="col-md-8">
                 {% for widget in field %}<div class="form-check">{{ widget }}</div>{% endfor %}
@@ -19,7 +20,8 @@
             </div>
         </div>
     {% elif label and not field.id_for_label %}
-        <fieldset class="mb-3 row{% if classes %} {{ classes }}{% endif %}{% if field.field.is_honeypot %} d-none honigtopf{% endif %}">
+        <fieldset class="mb-3 row{% if classes %} {{ classes }}{% endif %}{% if field.field.is_honeypot %} d-none honigtopf{% endif %}"
+                  {% if field.aria_describedby %}aria-describedby="{{ field.aria_describedby }}"{% endif %}>
             <legend class="fw-bold col-md-4 col-form-label{% if required %} field-required{% endif %}">{{ label }}</legend>
             <div class="col-md-8">
                 {{ field }}

--- a/froide/helper/templates/helper/forms/bootstrap_field.html
+++ b/froide/helper/templates/helper/forms/bootstrap_field.html
@@ -4,10 +4,7 @@
             <legend class="fw-bold col-form-label col-md-4{% if required %} field-required{% endif %}">{{ label }}</legend>
             <div class="col-md-8">
                 {% for widget in field %}<div class="form-check">{{ widget }}</div>{% endfor %}
-                {% if help_text %}<div class="form-text">{{ help_text }}</div>{% endif %}
-                {% if field.errors %}
-                    <div class="invalid-feedback">{% include "helper/forms/errors.html" with errors=field.errors %}</div>
-                {% endif %}
+                {% include "helper/forms/field_footer.html" %}
             </div>
         </fieldset>
     {% elif field_type == "checkbox" %}
@@ -17,10 +14,7 @@
                     {{ field }}
                     <label class="form-check-label fw-bold {% if required %}field-required{% endif %}"
                            for="{{ field.id_for_label }}">{{ label }}</label>
-                    {% if help_text %}<div class="form-text">{{ help_text }}</div>{% endif %}
-                    {% if field.errors %}
-                        <div class="invalid-feedback">{% include "helper/forms/errors.html" with errors=field.errors %}</div>
-                    {% endif %}
+                    {% include "helper/forms/field_footer.html" %}
                 </div>
             </div>
         </div>
@@ -29,10 +23,7 @@
             <legend class="fw-bold col-md-4 col-form-label{% if required %} field-required{% endif %}">{{ label }}</legend>
             <div class="col-md-8">
                 {{ field }}
-                {% if help_text %}<div class="form-text">{{ help_text }}</div>{% endif %}
-                {% if field.errors %}
-                    <div class="invalid-feedback">{% include "helper/forms/errors.html" with errors=field.errors %}</div>
-                {% endif %}
+                {% include "helper/forms/field_footer.html" %}
             </div>
         </fieldset>
     {% else %}
@@ -47,10 +38,7 @@
             {% endif %}
             <div class="col-md-8">
                 {{ field }}
-                {% if help_text %}<div class="form-text">{{ help_text }}</div>{% endif %}
-                {% if field.errors %}
-                    <div class="invalid-feedback">{% include "helper/forms/errors.html" with errors=field.errors %}</div>
-                {% endif %}
+                {% include "helper/forms/field_footer.html" %}
             </div>
         </div>
     {% endif %}

--- a/froide/helper/templates/helper/forms/bootstrap_field_inline.html
+++ b/froide/helper/templates/helper/forms/bootstrap_field_inline.html
@@ -3,10 +3,7 @@
         <div class="mb-3{% if classes %} {{ classes }}{% endif %}">
             {% if label and show_label %}<p class="form-label">{{ label }}</p>{% endif %}
             {% for widget in field %}<div class="form-check form-check-inline">{{ widget }}</div>{% endfor %}
-            {% if help_text %}<small class="form-text">{{ help_text }}</small>{% endif %}
-            {% if field.errors %}
-                <small class="form-text">{% include "helper/forms/errors.html" with errors=field.errors %}</small>
-            {% endif %}
+            {% include "helper/forms/field_footer.html" with inline=True %}
         </div>
     {% elif field_type == "checkbox" %}
         <div class="mb-3{% if classes %} {{ classes }}{% endif %}">
@@ -14,18 +11,12 @@
                 {{ field }}
                 <label class="form-check-label">{{ label }}</label>
             </div>
-            {% if help_text %}<small class="form-text">{{ help_text }}</small>{% endif %}
-            {% if field.errors %}
-                <small class="form-text">{% include "helper/forms/errors.html" with errors=field.errors %}</small>
-            {% endif %}
+            {% include "helper/forms/field_footer.html" with inline=True %}
         </div>
     {% else %}
         <div class="mb-3{% if classes %} {{ classes }}{% endif %}{% if field.field.is_honeypot %} d-none honigtopf{% endif %}">
             {{ field }}
-            {% if help_text %}<small class="form-text">{{ help_text }}</small>{% endif %}
-            {% if field.errors %}
-                <small class="form-text">{% include "helper/forms/errors.html" with errors=field.errors %}</small>
-            {% endif %}
+            {% include "helper/forms/field_footer.html" with inline=True %}
         </div>
     {% endif %}
 {% endwith %}

--- a/froide/helper/templates/helper/forms/bootstrap_field_inline.html
+++ b/froide/helper/templates/helper/forms/bootstrap_field_inline.html
@@ -1,8 +1,10 @@
 {% with classes=field.css_classes label=label|default:field.label help_text=help_text|default:field.help_text required=field.field.required %}
     {% if field_type == "radio" or is_checkboxmultiple %}
         <div class="mb-3{% if classes %} {{ classes }}{% endif %}">
-            {% if label and show_label %}<p class="form-label">{{ label }}</p>{% endif %}
-            {% for widget in field %}<div class="form-check form-check-inline">{{ widget }}</div>{% endfor %}
+            <fieldset>
+                {% if label and show_label %}<legend class="form-label fs-6">{{ label }}</legend>{% endif %}
+                {% for widget in field %}<div class="form-check form-check-inline">{{ widget }}</div>{% endfor %}
+            </fieldset>
             {% include "helper/forms/field_footer.html" with inline=True %}
         </div>
     {% elif field_type == "checkbox" %}

--- a/froide/helper/templates/helper/forms/bootstrap_field_inline.html
+++ b/froide/helper/templates/helper/forms/bootstrap_field_inline.html
@@ -1,7 +1,7 @@
 {% with classes=field.css_classes label=label|default:field.label help_text=help_text|default:field.help_text required=field.field.required %}
     {% if field_type == "radio" or is_checkboxmultiple %}
         <div class="mb-3{% if classes %} {{ classes }}{% endif %}">
-            <fieldset>
+            <fieldset {% if field.aria_describedby %}aria-describedby="{{ field.aria_describedby }}"{% endif %}>
                 {% if label and show_label %}<legend class="form-label fs-6">{{ label }}</legend>{% endif %}
                 {% for widget in field %}<div class="form-check form-check-inline">{{ widget }}</div>{% endfor %}
             </fieldset>

--- a/froide/helper/templates/helper/forms/bootstrap_field_stacked.html
+++ b/froide/helper/templates/helper/forms/bootstrap_field_stacked.html
@@ -1,7 +1,7 @@
 {% with classes=field.css_classes label=label|default:field.label help_text=help_text|default:field.help_text required=field.field.required %}
     <div class="mb-3{% if classes %} {{ classes }}{% endif %}{% if field.field.is_honeypot %} d-none honigtopf{% endif %}">
         {% if field_type == "radio" or is_checkboxmultiple %}
-            <fieldset>
+            <fieldset {% if field.aria_describedby %}aria-describedby="{{ field.aria_describedby }}"{% endif %}>
                 {% if label and show_label %}
                     <legend class="fw-bold form-label fs-6{% if required %} field-required{% endif %}">{{ label }}</legend>
                 {% endif %}

--- a/froide/helper/templates/helper/forms/bootstrap_field_stacked.html
+++ b/froide/helper/templates/helper/forms/bootstrap_field_stacked.html
@@ -1,10 +1,12 @@
 {% with classes=field.css_classes label=label|default:field.label help_text=help_text|default:field.help_text required=field.field.required %}
     <div class="mb-3{% if classes %} {{ classes }}{% endif %}{% if field.field.is_honeypot %} d-none honigtopf{% endif %}">
         {% if field_type == "radio" or is_checkboxmultiple %}
-            {% if label and show_label %}
-                <label class="fw-bold form-label{% if required %} field-required{% endif %}">{{ label }}</label>
-            {% endif %}
-            {% for widget in field %}<div class="form-check">{{ widget }}</div>{% endfor %}
+            <fieldset>
+                {% if label and show_label %}
+                    <legend class="fw-bold form-label fs-6{% if required %} field-required{% endif %}">{{ label }}</legend>
+                {% endif %}
+                {% for widget in field %}<div class="form-check">{{ widget }}</div>{% endfor %}
+            </fieldset>
         {% elif field_type == "checkbox" %}
             <div class="form-check">
                 {{ field }}

--- a/froide/helper/templates/helper/forms/bootstrap_field_stacked.html
+++ b/froide/helper/templates/helper/forms/bootstrap_field_stacked.html
@@ -22,9 +22,6 @@
             {% endif %}
             {{ field }}
         {% endif %}
-        {% if help_text %}<div class="form-text">{{ help_text }}</div>{% endif %}
-        {% if field.errors %}
-            <div class="invalid-feedback">{% include "helper/forms/errors.html" with errors=field.errors %}</div>
-        {% endif %}
+        {% include "helper/forms/field_footer.html" %}
     </div>
 {% endwith %}

--- a/froide/helper/templates/helper/forms/field_footer.html
+++ b/froide/helper/templates/helper/forms/field_footer.html
@@ -1,0 +1,8 @@
+{% with tag=inline|yesno:"small,div" error_class=inline|yesno:"form-text,invalid-feedback" %}
+    {% if help_text %}<{{ tag }} class="form-text">{{ help_text }}</{{ tag }}>{% endif %}
+    {% if field.errors %}
+        <{{ tag }} class="{{ error_class }}">
+        {% include "helper/forms/errors.html" with errors=field.errors %}
+        </{{ tag }}>
+    {% endif %}
+{% endwith %}

--- a/froide/helper/templates/helper/forms/field_footer.html
+++ b/froide/helper/templates/helper/forms/field_footer.html
@@ -1,8 +1,6 @@
-{% with tag=inline|yesno:"small,div" error_class=inline|yesno:"form-text,invalid-feedback" %}
+{% with tag=inline|yesno:"small,div" %}
     {% if help_text %}<{{ tag }} class="form-text">{{ help_text }}</{{ tag }}>{% endif %}
-    {% if field.errors %}
-        <{{ tag }} class="{{ error_class }}">
-        {% include "helper/forms/errors.html" with errors=field.errors %}
-        </{{ tag }}>
-    {% endif %}
 {% endwith %}
+{% if field.errors %}
+    <div class="invalid-feedback d-block">{% include "helper/forms/errors.html" with errors=field.errors %}</div>
+{% endif %}

--- a/froide/helper/templates/helper/forms/field_footer.html
+++ b/froide/helper/templates/helper/forms/field_footer.html
@@ -1,6 +1,13 @@
 {% with tag=inline|yesno:"small,div" %}
-    {% if help_text %}<{{ tag }} class="form-text">{{ help_text }}</{{ tag }}>{% endif %}
+    {% if help_text %}
+        <{{ tag }} class="form-text"
+        {% if field.auto_id %}id="{{ field.auto_id }}_helptext"{% endif %}
+        >{{ help_text }}</{{ tag }}>
+    {% endif %}
 {% endwith %}
 {% if field.errors %}
-    <div class="invalid-feedback d-block">{% include "helper/forms/errors.html" with errors=field.errors %}</div>
+    <div class="invalid-feedback d-block"
+         {% if field.auto_id %}id="{{ field.auto_id }}_error"{% endif %}>
+        {% include "helper/forms/errors.html" with errors=field.errors %}
+    </div>
 {% endif %}

--- a/froide/helper/tests/test_form_helper.py
+++ b/froide/helper/tests/test_form_helper.py
@@ -1,0 +1,142 @@
+from django import forms
+
+import pytest
+from lxml.html import HtmlElement, fragment_fromstring
+
+from ..templatetags.form_helper import render_field
+
+CHOICES = [("a", "A"), ("b", "B")]
+
+# The templates `render_field` picks between, as its keyword arguments.
+VARIANTS = {
+    "horizontal": {},
+    "stacked": {"stacked": True},
+    "inline": {"inline": True},
+}
+
+
+class DescribedForm(forms.Form):
+    """One field per branch of the field templates, each with a help text."""
+
+    text = forms.CharField(help_text="Help for text")
+    textarea = forms.CharField(widget=forms.Textarea, help_text="Help for textarea")
+    select = forms.ChoiceField(choices=CHOICES, help_text="Help for select")
+    checkbox = forms.BooleanField(help_text="Help for checkbox")
+    radio = forms.ChoiceField(
+        widget=forms.RadioSelect, choices=CHOICES, help_text="Help for radio"
+    )
+    multi = forms.MultipleChoiceField(
+        widget=forms.CheckboxSelectMultiple,
+        choices=CHOICES,
+        help_text="Help for multi",
+    )
+
+
+FIELD_NAMES = list(DescribedForm().fields)
+
+
+def render(
+    form: DescribedForm, field_name: str, variant: str
+) -> tuple[forms.BoundField, HtmlElement]:
+    """Render a field using our custom Bootstrap form field templates."""
+
+    field = form[field_name]
+    html = render_field(field, **VARIANTS[variant])
+    return field, fragment_fromstring(html, create_parent="div")
+
+
+def present_ids(tree: HtmlElement) -> set[str]:
+    """Every id defined in the field's markup - every possible reference target."""
+
+    return set(tree.xpath("//@id"))
+
+
+def referenced_ids(tree: HtmlElement) -> set[str]:
+    """Every id referenced by an `aria-describedby` in the field's markup."""
+
+    ids = set()
+    for element in tree.iter():
+        # `aria-describedby` holds a whitespace-separated list of ids.
+        ids.update(element.get("aria-describedby", "").split())
+    return ids
+
+
+def hidden_errors(tree: HtmlElement) -> list[HtmlElement]:
+    """The error blocks that Bootstrap will not display.
+
+    `.invalid-feedback` is `display: none` until a preceding sibling carries
+    `.is-invalid`, so a control nested in a `.form-check` never reveals the block
+    below the group. A block with `d-block` is displayed wherever it sits.
+    """
+
+    return [
+        block
+        for block in tree.xpath('//*[contains(@class, "invalid-feedback")]')
+        if "d-block" not in (block.get("class") or "")
+        and not any(
+            "is-invalid" in (sibling.get("class") or "")
+            for sibling in block.itersiblings(preceding=True)
+        )
+    ]
+
+
+@pytest.mark.parametrize("variant", VARIANTS)
+@pytest.mark.parametrize("field_name", FIELD_NAMES)
+def test_help_text_is_linked(field_name: str, variant: str):
+    field, tree = render(DescribedForm(), field_name, variant)
+    help_id = f"{field.auto_id}_helptext"
+
+    assert help_id in present_ids(tree), (
+        f"{field_name}: help text is rendered without the expected id "
+        f"({help_id}), so it cannot be referenced"
+    )
+    assert help_id in referenced_ids(tree), (
+        f"{field_name}: nothing references the help text ({help_id}), so a "
+        "screen reader does not announce it"
+    )
+
+
+@pytest.mark.parametrize("variant", VARIANTS)
+@pytest.mark.parametrize("field_name", FIELD_NAMES)
+def test_error_is_linked(field_name: str, variant: str):
+    # Every field is required, so an empty submission puts an error on each.
+    form = DescribedForm(data={})
+    assert form[field_name].errors
+
+    field, tree = render(form, field_name, variant)
+    error_id = f"{field.auto_id}_error"
+
+    assert error_id in present_ids(tree), (
+        f"{field_name}: the error message is rendered without the expected "
+        f"id ({error_id}), so it cannot be referenced"
+    )
+    assert error_id in referenced_ids(tree), (
+        f"{field_name}: nothing references the error message ({error_id}), so "
+        "a screen reader does not announce it"
+    )
+
+
+@pytest.mark.parametrize("variant", VARIANTS)
+@pytest.mark.parametrize("field_name", FIELD_NAMES)
+def test_error_is_displayed(field_name: str, variant: str):
+    form = DescribedForm(data={})
+    assert form[field_name].errors
+
+    _, tree = render(form, field_name, variant)
+
+    assert not hidden_errors(tree), (
+        f"{field_name}: the error message is in the markup but never displayed"
+    )
+
+
+@pytest.mark.parametrize("variant", VARIANTS)
+@pytest.mark.parametrize("field_name", FIELD_NAMES)
+def test_no_dangling_references(field_name: str, variant: str):
+    # Bound and invalid, so help text and error are both referenced.
+    field, tree = render(DescribedForm(data={}), field_name, variant)
+
+    dangling = referenced_ids(tree) - present_ids(tree)
+    assert not dangling, (
+        f"{field_name}: aria-describedby points to ids that do not exist in "
+        f"the markup: {', '.join(sorted(dangling))}"
+    )

--- a/froide/tests/live/snapshots/test_a11y/test_a11y_chromium_account_signup.txt
+++ b/froide/tests/live/snapshots/test_a11y/test_a11y_chromium_account_signup.txt
@@ -1,3 +1,2 @@
-incomplete:aria-valid-attr-value
 violations:color-contrast
 violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_a11y/test_a11y_foirequest_list_search_options_chromium.txt
+++ b/froide/tests/live/snapshots/test_a11y/test_a11y_foirequest_list_search_options_chromium.txt
@@ -1,4 +1,3 @@
-incomplete:aria-valid-attr-value
 incomplete:color-contrast
 violations:color-contrast
 violations:heading-order

--- a/froide/tests/live/snapshots/test_a11y/test_a11y_foirequest_list_search_options_chromium.txt
+++ b/froide/tests/live/snapshots/test_a11y/test_a11y_foirequest_list_search_options_chromium.txt
@@ -1,0 +1,6 @@
+incomplete:aria-valid-attr-value
+incomplete:color-contrast
+violations:color-contrast
+violations:heading-order
+violations:page-has-heading-one
+violations:select-name

--- a/froide/tests/live/snapshots/test_a11y/test_a11y_logged_in_chromium_account_confirmed.txt
+++ b/froide/tests/live/snapshots/test_a11y/test_a11y_logged_in_chromium_account_confirmed.txt
@@ -1,3 +1,2 @@
-incomplete:aria-valid-attr-value
 violations:heading-order
 violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_a11y/test_a11y_logged_in_chromium_account_confirmed.txt
+++ b/froide/tests/live/snapshots/test_a11y/test_a11y_logged_in_chromium_account_confirmed.txt
@@ -1,0 +1,3 @@
+incomplete:aria-valid-attr-value
+violations:heading-order
+violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_a11y/test_a11y_logged_in_chromium_account_settings.txt
+++ b/froide/tests/live/snapshots/test_a11y/test_a11y_logged_in_chromium_account_settings.txt
@@ -1,4 +1,3 @@
-incomplete:aria-valid-attr-value
 incomplete:color-contrast
 violations:color-contrast
 violations:heading-order

--- a/froide/tests/live/snapshots/test_a11y/test_a11y_logged_in_chromium_account_settings.txt
+++ b/froide/tests/live/snapshots/test_a11y/test_a11y_logged_in_chromium_account_settings.txt
@@ -1,0 +1,6 @@
+incomplete:aria-valid-attr-value
+incomplete:color-contrast
+violations:color-contrast
+violations:heading-order
+violations:label
+violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_a11y/test_a11y_logged_in_chromium_publicbody_propose.txt
+++ b/froide/tests/live/snapshots/test_a11y/test_a11y_logged_in_chromium_publicbody_propose.txt
@@ -1,0 +1,6 @@
+incomplete:aria-required-children
+incomplete:aria-valid-attr-value
+incomplete:color-contrast
+violations:color-contrast
+violations:label
+violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_a11y/test_a11y_logged_in_chromium_publicbody_propose.txt
+++ b/froide/tests/live/snapshots/test_a11y/test_a11y_logged_in_chromium_publicbody_propose.txt
@@ -1,5 +1,4 @@
 incomplete:aria-required-children
-incomplete:aria-valid-attr-value
 incomplete:color-contrast
 violations:color-contrast
 violations:label

--- a/froide/tests/live/snapshots/test_a11y/test_a11y_staff_chromium_document_upload.txt
+++ b/froide/tests/live/snapshots/test_a11y/test_a11y_staff_chromium_document_upload.txt
@@ -1,6 +1,5 @@
 incomplete:aria-prohibited-attr
 incomplete:aria-required-children
-incomplete:aria-valid-attr-value
 incomplete:color-contrast
 violations:color-contrast
 violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_a11y/test_a11y_staff_chromium_document_upload.txt
+++ b/froide/tests/live/snapshots/test_a11y/test_a11y_staff_chromium_document_upload.txt
@@ -1,0 +1,6 @@
+incomplete:aria-prohibited-attr
+incomplete:aria-required-children
+incomplete:aria-valid-attr-value
+incomplete:color-contrast
+violations:color-contrast
+violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_chromium_account_confirmed.txt
+++ b/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_chromium_account_confirmed.txt
@@ -1,4 +1,3 @@
-incomplete:aria-valid-attr-value
 violations:heading-order
 violations:link-in-text-block
 violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_request/test_set_status_chromium_unset_successful_detail.txt
+++ b/froide/tests/live/snapshots/test_request/test_set_status_chromium_unset_successful_detail.txt
@@ -1,5 +1,4 @@
 incomplete:aria-prohibited-attr
-incomplete:aria-valid-attr-value
 incomplete:color-contrast
 incomplete:link-in-text-block
 violations:aria-required-children

--- a/froide/tests/live/snapshots/test_request/test_set_status_chromium_unset_successful_edit_panel.txt
+++ b/froide/tests/live/snapshots/test_request/test_set_status_chromium_unset_successful_edit_panel.txt
@@ -1,4 +1,3 @@
-incomplete:aria-valid-attr-value
 incomplete:color-contrast
 violations:label
 violations:label-title-only

--- a/froide/tests/live/test_a11y.py
+++ b/froide/tests/live/test_a11y.py
@@ -1,7 +1,9 @@
 from django.urls import reverse
 
 import pytest
-from playwright.async_api import Page
+from playwright.async_api import Page, expect
+
+from .utils import do_login
 
 # (url name, reverse kwargs)
 PAGES = [
@@ -11,14 +13,70 @@ PAGES = [
     ("foirequest-make_request", {}),
 ]
 
+# Pages that redirect anonymous visitors to the login page
+LOGGED_IN_PAGES = [
+    ("account-settings", {}),
+    ("account-confirmed", {}),
+    ("publicbody-propose", {}),
+]
+
+# Pages that are only shown to staff users
+STAFF_PAGES = [
+    ("document-upload", {}),
+]
+
+
+async def _check_page(page: Page, live_server, check_a11y, url_name: str, kwargs: dict):
+    response = await page.goto(live_server.url + reverse(url_name, kwargs=kwargs))
+    assert response is not None
+    assert response.status == 200, f"{url_name} returned HTTP {response.status}"
+
+    await check_a11y(page)
+
 
 @pytest.mark.django_db
 @pytest.mark.xdist_group(name="sequential")
 @pytest.mark.asyncio(loop_scope="session")
 @pytest.mark.parametrize("url_name,kwargs", PAGES, ids=[entry[0] for entry in PAGES])
 async def test_a11y(page: Page, live_server, check_a11y, url_name: str, kwargs: dict):
-    response = await page.goto(live_server.url + reverse(url_name, kwargs=kwargs))
-    assert response is not None
-    assert response.status == 200, f"{url_name} returned HTTP {response.status}"
+    await _check_page(page, live_server, check_a11y, url_name, kwargs)
+
+
+@pytest.mark.django_db
+@pytest.mark.xdist_group(name="sequential")
+@pytest.mark.asyncio(loop_scope="session")
+@pytest.mark.parametrize(
+    "url_name,kwargs", LOGGED_IN_PAGES, ids=[entry[0] for entry in LOGGED_IN_PAGES]
+)
+async def test_a11y_logged_in(
+    page: Page, live_server, check_a11y, dummy_user, url_name: str, kwargs: dict
+):
+    await do_login(page, live_server)
+    await _check_page(page, live_server, check_a11y, url_name, kwargs)
+
+
+@pytest.mark.django_db
+@pytest.mark.xdist_group(name="sequential")
+@pytest.mark.asyncio(loop_scope="session")
+@pytest.mark.parametrize(
+    "url_name,kwargs", STAFF_PAGES, ids=[entry[0] for entry in STAFF_PAGES]
+)
+async def test_a11y_staff(
+    page: Page, live_server, check_a11y, dummy_staff_user, url_name: str, kwargs: dict
+):
+    await do_login(page, live_server, username=dummy_staff_user.username)
+    await _check_page(page, live_server, check_a11y, url_name, kwargs)
+
+
+@pytest.mark.django_db
+@pytest.mark.xdist_group(name="sequential")
+@pytest.mark.asyncio(loop_scope="session")
+async def test_a11y_foirequest_list_search_options(page: Page, live_server, check_a11y):
+    """FOI request list with opened additional search options"""
+
+    await page.goto(live_server.url + reverse("foirequest-list"))
+
+    await page.locator("details > summary").click()
+    await expect(page.locator("details[open]")).to_have_count(1)
 
     await check_a11y(page)

--- a/froide/tests/live/utils.py
+++ b/froide/tests/live/utils.py
@@ -27,9 +27,9 @@ async def go_to_request_page(page, live_server, foirequest):
 
 
 @pytest.mark.asyncio(loop_scope="session")
-async def do_login(page, live_server):
+async def do_login(page, live_server, username="dummy"):
     await page.goto(live_server.url + reverse("account-login"))
-    user = User.objects.get(username="dummy")
+    user = User.objects.get(username=username)
     await page.fill("[name=username]", user.email)
     await page.fill("[name=password]", "froide")
     await page.locator('button.btn.btn-primary[type="submit"]').click()


### PR DESCRIPTION
Django sets `aria-describedby="<auto_id>_helptext <auto_id>_error"` on form widgets [automatically](https://docs.djangoproject.com/en/5.2/ref/forms/api/#django.forms.BoundField.aria_describedby), but our Bootstrap field templates rendered help texts and error messages without any id, so every described field pointed at elements that didn't exist. For widgets that use a fieldset (radio groups, multiple checkboxes) [Django leaves the attribute to the template](https://github.com/django/django/blob/4ea267661b260ea0d0c87e9dcb99d70037c6f2fc/django/forms/boundfield.py#L294), and ours never set it, so help text and errors weren't announced at all.                                                                                            
                                                                                                                                                                                                                                                       
### Changes                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                          
  - Factor out a `field_footer.html` partial shared by the horizontal, stacked and inline field templates, replacing four near-identical copies of the help-text/error markup.                                                                                               
  - Give help texts and errors the ids Django expects and set `aria-describedby` on the `<fieldset>` for widgets that use one. Radio/checkbox groups in the stacked and inline templates now use a real `<fieldset>/<legend>` instead of a label plus loose checkboxes.                                                                                                                                                                                                                                       
  - Show errors that Bootstrap kept hidden: `.invalid-feedback` stays `display: none` unless a preceding sibling has `.is-invalid`, which never happens for controls nested in a `.form-check`. The field footer partial adds `d-block` so error messages are actually displayed.
  - Fix the `hide_project_duplicates` checkbox in `_request_search.html`, whose help text is written out by hand rather than through the field templates and so was missing the id too.               
  
### Tests                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                           
  - New `froide/helper/tests/test_form_helper.py`: renders every widget type through all three template variants and asserts that help text and errors are present, referenced, displayed, and that no `aria-describedby` points at a missing id.                              
  - Extend end-to-end a11y test coverage for pages that previously had these problems.                                                                                                                                                                                                          
  - Update a11y snapshots to capture the fixed violation (`aria-valid-attr-value`).

Closes https://github.com/fragdenstaat/issues/issues/380