### PR TITLE
move form hint regarding pseudonyms to first name in registration form

### DIFF
--- a/froide/account/forms.py
+++ b/froide/account/forms.py
@@ -188,7 +188,7 @@ class NewUserBaseForm(AddressBaseForm):
         super().__init__(*args, **kwargs)
         self.fields["address"].required = address_required
         if ALLOW_PSEUDONYM and not address_required:
-            self.fields["last_name"].help_text = format_html(
+            self.fields["first_name"].help_text = format_html(
                 _(
                     '<a target="_blank" href="{}">You may use a pseudonym if you don\'t need to receive postal messages</a>.'
                 ),


### PR DESCRIPTION
refs https://github.com/fragdenstaat/issues/issues/135 as an "improvement for now"

> Im Registrierungsformular selbst sollte der Hinweis auf die Möglichkeit zur Nutzung eines Pseudonyms bereits vor den Eingabefeldern für Vor- und Nachnamens erfolgen. Wenn Nutzende die Seite linear abarbeiten, beispielsweise weil sie einen Screenreader nutzen, könnten sie davon ausgehen, dass zu einem späteren Zeitpunkt ein weiteres Eingabefeld für das Pseudonym folgt. Dies ist jedoch nicht der Fall.