### PR TITLE
Improve a11y on request page

### DIFF
--- a/froide/foirequest/templates/foirequest/body/message/_badge.html
+++ b/froide/foirequest/templates/foirequest/body/message/_badge.html
@@ -1,0 +1,7 @@
+<span class="alpha-message__badge {{ badge_class }}"
+      data-bs-toggle="tooltip"
+      title="{{ label }}"
+      role="img"
+      aria-label="{{ label }}">
+    <span class="fa {{ icon_class }}" aria-hidden="true"></span>
+</span>

--- a/froide/foirequest/templates/foirequest/body/message/message.html
+++ b/froide/foirequest/templates/foirequest/body/message/message.html
@@ -18,7 +18,8 @@
         <button type="button"
                 class="alpha-message__expand-toggle d-print-none"
                 aria-expanded="{% if message.timestamp == object.last_message %}true{% else %}false{% endif %}"
-                aria-controls="{{ message.get_html_id }}-body">
+                aria-controls="{{ message.get_html_id }}-body"
+                title="{% trans "Toggle message" %}">
             <i class="fa fa-angle-down alpha-message__expand-chevron"
                aria-hidden="true"></i>
             <span class="visually-hidden">{% trans "Toggle message" %}</span>

--- a/froide/foirequest/templates/foirequest/body/message/message.html
+++ b/froide/foirequest/templates/foirequest/body/message/message.html
@@ -34,18 +34,12 @@
                 {# icons & timestamp #}
                 <div class="d-flex flex-nowrap">
                     {% if message.all_attachments %}
-                        <span class="alpha-message__badge"
-                              data-bs-toggle="tooltip"
-                              title="{% trans 'Has attachments' %}">
-                            <span class="fa fa-paperclip"></span>
-                        </span>
+                        {% translate "Has attachments" as attachments_label %}
+                        {% include "foirequest/body/message/_badge.html" with icon_class="fa-paperclip" label=attachments_label %}
                     {% endif %}
                     {% if comment_list %}
-                        <span class="alpha-message__badge"
-                              data-bs-toggle="tooltip"
-                              title="{% trans 'Has comments' %}">
-                            <span class="fa fa-comment-o"></span>
-                        </span>
+                        {% translate "Has comments" as comments_label %}
+                        {% include "foirequest/body/message/_badge.html" with icon_class="fa-comment-o" label=comments_label %}
                     {% endif %}
                     {% if message.is_not_email %}
                         {% if message.is_response %}
@@ -53,40 +47,24 @@
                         {% else %}
                             {% blocktrans with kind=message.get_kind_display asvar kind_display %}sent via {{ kind }}{% endblocktrans %}
                         {% endif %}
-                        <span class="alpha-message__badge alpha-message__badge--kind"
-                              data-bs-toggle="tooltip"
-                              title="{{ kind_display }}">
-                            <span class="fa fa-{{ message.kind_icon }}"></span>
-                        </span>
+                        {% include "foirequest/body/message/_badge.html" with badge_class="alpha-message__badge--kind" icon_class="fa-"|add:message.kind_icon label=kind_display %}
                     {% endif %}
                     {% if message.request|can_read_foirequest_authenticated:request and message.is_response and message.is_email and message.fails_authenticity %}
-                        <span class="alpha-message__badge alpha-message__badge--error"
-                              data-bs-toggle="tooltip"
-                              title="{% translate 'Possible authenticity problems with this message have been detected.' %}">
-                            <span class="fa fa-user-secret"></span>
-                        </span>
+                        {% translate "Possible authenticity problems with this message have been detected." as authenticity_label %}
+                        {% include "foirequest/body/message/_badge.html" with badge_class="alpha-message__badge--error" icon_class="fa-user-secret" label=authenticity_label %}
                     {% endif %}
                     {% if message.is_escalation_message %}
-                        <span class="alpha-message__badge alpha-message__badge--kind"
-                              data-bs-toggle="tooltip"
-                              title="{% blocktrans %}Message to the mediation authority.{% endblocktrans %}">
-                            <span class="fa fa-shield"></span>
-                        </span>
+                        {% translate "Message to the mediation authority." as escalation_label %}
+                        {% include "foirequest/body/message/_badge.html" with badge_class="alpha-message__badge--kind" icon_class="fa-shield" label=escalation_label %}
                     {% endif %}
                     {% if message.content_hidden %}
-                        <span class="alpha-message__badge alpha-message__badge--kind"
-                              data-bs-toggle="tooltip"
-                              title="{% blocktrans %}This message is not yet public.{% endblocktrans %}">
-                            <span class="fa fa-lock"></span>
-                        </span>
+                        {% translate "This message is not yet public." as hidden_label %}
+                        {% include "foirequest/body/message/_badge.html" with badge_class="alpha-message__badge--kind" icon_class="fa-lock" label=hidden_label %}
                     {% endif %}
                     {% get_delivery_status message as delivery_status %}
                     {% if delivery_status.is_failed %}
-                        <span class="alpha-message__badge alpha-message__badge--error"
-                              data-bs-toggle="tooltip"
-                              title="{% blocktrans with kind=message.get_kind_display %}{{ kind }} delivery has failed.{% endblocktrans %}">
-                            <span class="fa fa-bolt"></span>
-                        </span>
+                        {% blocktrans with kind=message.get_kind_display asvar delivery_failed_label %}{{ kind }} delivery has failed.{% endblocktrans %}
+                        {% include "foirequest/body/message/_badge.html" with badge_class="alpha-message__badge--error" icon_class="fa-bolt" label=delivery_failed_label %}
                     {% endif %}
                     {# relative time #}
                     <a href="#{{ message.get_html_id }}"

--- a/froide/foirequest/templates/foirequest/body/message/message.html
+++ b/froide/foirequest/templates/foirequest/body/message/message.html
@@ -14,6 +14,15 @@
     {# head #}
     <div {% if message.timestamp == object.last_message %}id="last"{% endif %}
          class="d-flex p-3 alpha-message__head">
+        {# expand/collapse message #}
+        <button type="button"
+                class="alpha-message__expand-toggle d-print-none"
+                aria-expanded="{% if message.timestamp == object.last_message %}true{% else %}false{% endif %}"
+                aria-controls="{{ message.get_html_id }}-body">
+            <i class="fa fa-angle-down alpha-message__expand-chevron"
+               aria-hidden="true"></i>
+            <span class="visually-hidden">{% trans "Toggle message" %}</span>
+        </button>
         {# avatar #}
         <div class="alpha-message__avatar alpha-message__avatar--{% if message.is_response %}{% if message.is_mediator %}shield{% else %}house{% endif %}{% else %}user{% endif %}">
             {% if not message.is_response and not message.sender_user.private and message.sender_user.profile_photo %}
@@ -99,17 +108,21 @@
                     </span>
                 {% endif %}
                 <!-- delivery details link-->
-                <a href="#" class="alpha-message__meta-toggle text-body">
+                <button type="button"
+                        class="alpha-message__meta-toggle text-body"
+                        aria-expanded="false"
+                        aria-controls="{{ message.get_html_id }}-meta">
                     {% trans "Details" %}
-                    <i class="fa fa-angle-down" aria-hidden="true"></i>
-                </a>
+                    <i class="fa fa-angle-down alpha-message__meta-chevron"
+                       aria-hidden="true"></i>
+                </button>
             </div>
         </div>
     </div>
     {# meta details container #}
     {% include "foirequest/body/message/meta_container.html" %}
     {# body #}
-    <div class="alpha-message__body">
+    <div id="{{ message.get_html_id }}-body" class="alpha-message__body">
         <div class="alpha-message__wrap alpha-message__bodyinner">
             {# guidance #}
             {% if not message.content_hidden or object|can_read_foirequest_authenticated:request %}

--- a/froide/foirequest/templates/foirequest/body/message/message.html
+++ b/froide/foirequest/templates/foirequest/body/message/message.html
@@ -17,7 +17,7 @@
         {# expand/collapse message #}
         <button type="button"
                 class="alpha-message__expand-toggle d-print-none"
-                aria-expanded="{% if message.timestamp == object.last_message %}true{% else %}false{% endif %}"
+                aria-expanded="false"
                 aria-controls="{{ message.get_html_id }}-body"
                 title="{% trans "Toggle message" %}">
             <i class="fa fa-angle-down alpha-message__expand-chevron"
@@ -113,9 +113,9 @@
                         class="alpha-message__meta-toggle text-body"
                         aria-expanded="false"
                         aria-controls="{{ message.get_html_id }}-meta">
-                    {% trans "Details" %}
                     <i class="fa fa-angle-down alpha-message__meta-chevron"
                        aria-hidden="true"></i>
+                    {% trans "Details" %}
                 </button>
             </div>
         </div>

--- a/froide/foirequest/templates/foirequest/body/message/meta_container.html
+++ b/froide/foirequest/templates/foirequest/body/message/meta_container.html
@@ -1,7 +1,8 @@
 {% load i18n %}
 {% load foirequest_tags %}
 {% load permission_helper %}
-<div class="alpha-message__meta-container alpha-message__wrap">
+<div id="{{ message.get_html_id }}-meta"
+     class="alpha-message__meta-container alpha-message__wrap">
     {% block before_meta %}
     {% endblock before_meta %}
     <dl class="message-meta mb-0 row">

--- a/froide/foirequest/templates/foirequest/body/timeline.html
+++ b/froide/foirequest/templates/foirequest/body/timeline.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 {% load content_helper %}
 {% block foirequest_timeline %}
+    <h4>{% trans "Timeline of this request" %}</h4>
     <div id="timeline" class="alpha-timeline d-none d-lg-block">
         <div class="alpha-timeline__wrap">
             {% for group in object.messages_by_month %}

--- a/froide/foirequest/templates/foirequest/body/timeline.html
+++ b/froide/foirequest/templates/foirequest/body/timeline.html
@@ -1,8 +1,8 @@
 {% load i18n %}
 {% load content_helper %}
 {% block foirequest_timeline %}
-    <h4>{% trans "Timeline of this request" %}</h4>
     <div id="timeline" class="alpha-timeline d-none d-lg-block">
+        <h3 class="h6">{% trans "Timeline of this request" %}</h3>
         <div class="alpha-timeline__wrap">
             {% for group in object.messages_by_month %}
                 <div class="alpha-timeline__item {% if group.show_overdue_message %}alpha-timeline__item--overdue{% endif %} {% if forloop.last %}alpha-timeline__item--last{% endif %}"

--- a/froide/foirequest/templates/foirequest/body/timeline.html
+++ b/froide/foirequest/templates/foirequest/body/timeline.html
@@ -2,8 +2,8 @@
 {% load content_helper %}
 {% block foirequest_timeline %}
     <div id="timeline" class="alpha-timeline d-none d-lg-block">
-        <h3 class="h6">{% trans "Timeline of this request" %}</h3>
         <div class="alpha-timeline__wrap">
+            <h3 class="h6">{% trans "Timeline of this request" %}</h3>
             {% for group in object.messages_by_month %}
                 <div class="alpha-timeline__item {% if group.show_overdue_message %}alpha-timeline__item--overdue{% endif %} {% if forloop.last %}alpha-timeline__item--last{% endif %}"
                      data-key="{{ group.date|date:'Y-m' }}">

--- a/froide/foirequest/templates/foirequest/header/_tags.html
+++ b/froide/foirequest/templates/foirequest/header/_tags.html
@@ -24,11 +24,13 @@
                                         <i class="fa fa-pencil" aria-hidden="true"></i>
                                         <span class="visually-hidden">{% trans "Edit tags" %}</span>
                                     </a>
-                                    <span data-bs-toggle="tooltip"
-                                          title="{% translate 'Tags are a way to organise your own requests and also group them with other requests on the platform.' %}">
+                                    <button type="button"
+                                            class="btn btn-sm p-0 align-baseline"
+                                            data-bs-toggle="tooltip"
+                                            title="{% translate 'Tags are a way to organise your own requests and also group them with other requests on the platform.' %}">
                                         <i class="fa fa-question-circle-o" aria-hidden="true"></i>
                                         <span class="visually-hidden">{% translate "What does this mean?" %}</span>
-                                    </span>
+                                    </button>
                                 {% endif %}
                             </li>
                         </ul>
@@ -39,11 +41,13 @@
                         <i class="fa fa-pencil" aria-hidden="true"></i>
                         {% trans "Add tags" %}
                     </a>
-                    <span data-bs-toggle="tooltip"
-                          title="{% translate 'Tags are a way to organise your own requests and also group them with other requests on the platform.' %}">
+                    <button type="button"
+                            class="btn btn-sm p-0 align-baseline"
+                            data-bs-toggle="tooltip"
+                            title="{% translate 'Tags are a way to organise your own requests and also group them with other requests on the platform.' %}">
                         <i class="fa fa-question-circle-o" aria-hidden="true"></i>
                         <span class="visually-hidden">{% translate "What does this mean?" %}</span>
-                    </span>
+                    </button>
                 {% endif %}
             </div>
             <!-- tags form-->

--- a/froide/locale/de/LC_MESSAGES/django.po
+++ b/froide/locale/de/LC_MESSAGES/django.po
@@ -8299,6 +8299,10 @@ msgstr "An: {name}"
 msgid "Toggle collapse"
 msgstr "Ein-/Ausklappen"
 
+#: froide/foirequest/templates/foirequest/body/message/message.html
+msgid "Toggle message"
+msgstr "Nachricht ein-/ausklappen"
+
 #: froide/helper/spam.py
 msgid "Too many actions."
 msgstr "Zu viele Aktionen."

--- a/froide/locale/de/LC_MESSAGES/django.po
+++ b/froide/locale/de/LC_MESSAGES/django.po
@@ -10890,6 +10890,10 @@ msgstr "Organisationen"
 msgid "overdue"
 msgstr "verspätet"
 
+#: froide/foirequest/templates/foirequest/body/timeline.html
+msgid "Timeline of this request"
+msgstr "Verlauf dieser Anfrage"
+
 #: froide/foirequest/filters.py
 msgctxt "slug"
 msgid "overdue"

--- a/froide/locale/de/LC_MESSAGES/django.po
+++ b/froide/locale/de/LC_MESSAGES/django.po
@@ -432,7 +432,7 @@ msgstr "<p>Suchen Sie in unserem Archiv nach ähnlichen Anfragen, bevor Sie eine
 
 #: froide/foirequest/templates/foirequest/request.html
 msgid "<p>Your name will be sent to public bodies. If you want to remain anonymous to the public, you can choose to not display your name on the website. Your name will then be redacted.</p>"
-msgstr "<p>Ihr Name wird als Teil Ihrer Anfrage an die Behörde gesendet. Falls Sie wünschen, dass Ihr Name nicht auf der Website veröffentlicht wrid, können Sie – nach außen hin – anonym bleiben. Ihr Name wrid dann automatisch geschwärzt.</p>"
+msgstr "<p>Ihr Name wird als Teil Ihrer Anfrage an die Behörde gesendet. Falls Sie wünschen, dass Ihr Name nicht auf der Website veröffentlicht wird, können Sie – nach außen hin – anonym bleiben. Ihr Name wird dann automatisch geschwärzt.</p>"
 
 #: froide/foirequest/templates/foirequest/request.html
 #, python-format

--- a/frontend/javascript/components/request/Message.ts
+++ b/frontend/javascript/components/request/Message.ts
@@ -6,6 +6,7 @@ export default class Message {
   id: string
   element: HTMLElement
   metaContainer: HTMLElement
+  expandToggle: HTMLElement | null
   expandedClassName = 'alpha-message--expanded'
   metaExpandedClassName = 'alpha-message__meta-container--visible'
 
@@ -15,6 +16,9 @@ export default class Message {
     this.metaContainer = this.element.querySelector(
       '.alpha-message__meta-container'
     ) as HTMLElement
+    this.expandToggle = this.element.querySelector(
+      '.alpha-message__expand-toggle'
+    )
 
     // event listeners
 
@@ -22,6 +26,7 @@ export default class Message {
     element
       .querySelector('.alpha-message__head')
       ?.addEventListener('click', this.onHeadClick.bind(this))
+    this.expandToggle?.addEventListener('click', this.onHeadClick.bind(this))
     element
       .querySelector('.alpha-message__meta-toggle')
       ?.addEventListener('click', this.toggleMetaContainer.bind(this))
@@ -86,8 +91,9 @@ export default class Message {
   }
 
   onHeadClick(e: Event): void {
-    this.toggleMessage()
     e.preventDefault()
+    e.stopPropagation()
+    this.toggleMessage()
   }
 
   toggleMessage(): void {
@@ -104,12 +110,14 @@ export default class Message {
   expandMessage(): void {
     this.updateStorageItem({ isExpanded: true })
     this.element.classList.add(this.expandedClassName)
+    this.expandToggle?.setAttribute('aria-expanded', 'true')
   }
 
   collapseMessage(): void {
     this.updateStorageItem({ isExpanded: false })
     this.element.classList.remove(this.expandedClassName)
     this.metaContainer.classList.remove(this.metaExpandedClassName)
+    this.expandToggle?.setAttribute('aria-expanded', 'false')
   }
 
   showMetaContainer(): void {
@@ -121,7 +129,18 @@ export default class Message {
   toggleMetaContainer(e?: Event): void {
     e?.preventDefault()
     e?.stopPropagation()
+    const wasVisible = this.metaContainer.classList.contains(
+      this.metaExpandedClassName
+    )
     this.metaContainer.classList.toggle(this.metaExpandedClassName)
+
+    const toggle = this.element.querySelector(
+      '.alpha-message__meta-toggle'
+    ) as HTMLElement
+    if (toggle) {
+      const expanded = !wasVisible
+      toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false')
+    }
   }
 
   showAllAttachments(e: Event): void {

--- a/frontend/javascript/components/request/Message.ts
+++ b/frontend/javascript/components/request/Message.ts
@@ -7,6 +7,7 @@ export default class Message {
   element: HTMLElement
   metaContainer: HTMLElement
   expandToggle: HTMLElement | null
+  metaToggle: HTMLElement | null
   expandedClassName = 'alpha-message--expanded'
   metaExpandedClassName = 'alpha-message__meta-container--visible'
 
@@ -19,6 +20,7 @@ export default class Message {
     this.expandToggle = this.element.querySelector(
       '.alpha-message__expand-toggle'
     )
+    this.metaToggle = this.element.querySelector('.alpha-message__meta-toggle')
 
     // event listeners
 
@@ -26,33 +28,30 @@ export default class Message {
     element
       .querySelector('.alpha-message__head')
       ?.addEventListener('click', this.onHeadClick.bind(this))
-    this.expandToggle?.addEventListener('click', this.onHeadClick.bind(this))
-    element
-      .querySelector('.alpha-message__meta-toggle')
-      ?.addEventListener('click', this.toggleMetaContainer.bind(this))
+    this.metaToggle?.addEventListener(
+      'click',
+      this.toggleMetaContainer.bind(this)
+    )
     element
       .querySelectorAll('.alpha-attachment__more-trigger')
       .forEach((el) => {
         el.addEventListener('click', this.showAllAttachments.bind(this))
       })
 
-    // create storage item and/or expand message
-    if (!this.storageItem) {
-      // create localStorage item
-      try {
-        // localStorage access may cause DOMException if blocked
-        localStorage.setItem(
-          this.id,
-          JSON.stringify({ isExpanded: isLastItem || forceExpand })
-        )
-      } catch {
-        console.warn('Could not create localStorage item')
-      }
-      // maybe expand
-      if (isLastItem || forceExpand) this.expandMessage()
+    // A deep link (forceExpand) always expands. Otherwise a stored value is an
+    // explicit user choice and wins; without one, the last message starts
+    // expanded.
+    const shouldExpand =
+      (this.storageItem && this.isExpanded) ||
+      (!this.storageItem && isLastItem) ||
+      forceExpand
+
+    // expandMessage() / collapseMessage() persist the state, so the message and
+    // its storage item always agree.
+    if (shouldExpand) {
+      this.expandMessage()
     } else {
-      // expand message according to storage state
-      if (this.isExpanded || forceExpand) this.expandMessage()
+      this.collapseMessage()
     }
   }
 
@@ -116,8 +115,10 @@ export default class Message {
   collapseMessage(): void {
     this.updateStorageItem({ isExpanded: false })
     this.element.classList.remove(this.expandedClassName)
-    this.metaContainer.classList.remove(this.metaExpandedClassName)
     this.expandToggle?.setAttribute('aria-expanded', 'false')
+    // the meta container collapses along with the message
+    this.metaContainer.classList.remove(this.metaExpandedClassName)
+    this.metaToggle?.setAttribute('aria-expanded', 'false')
   }
 
   showMetaContainer(): void {
@@ -129,18 +130,10 @@ export default class Message {
   toggleMetaContainer(e?: Event): void {
     e?.preventDefault()
     e?.stopPropagation()
-    const wasVisible = this.metaContainer.classList.contains(
+    const isVisible = this.metaContainer.classList.toggle(
       this.metaExpandedClassName
     )
-    this.metaContainer.classList.toggle(this.metaExpandedClassName)
-
-    const toggle = this.element.querySelector(
-      '.alpha-message__meta-toggle'
-    ) as HTMLElement
-    if (toggle) {
-      const expanded = !wasVisible
-      toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false')
-    }
+    this.metaToggle?.setAttribute('aria-expanded', String(isVisible))
   }
 
   showAllAttachments(e: Event): void {

--- a/frontend/javascript/components/request/Timeline.ts
+++ b/frontend/javascript/components/request/Timeline.ts
@@ -249,8 +249,9 @@ export default class Timeline {
         continue
       }
 
-      const innerWrapElement = this.element.children[0] as HTMLElement
-      const timelineHeight = this.element.clientHeight
+      const innerWrapElement = this.element.querySelector(
+        '.alpha-timeline__wrap'
+      ) as HTMLElement
       const isVisible = entry.isIntersecting
       this.items[timelineKey].updateItemVisibility(msgId, isVisible)
 
@@ -266,25 +267,25 @@ export default class Timeline {
       const activeElements = document.querySelectorAll(
         '.alpha-timeline__item--active'
       )
-      const activeElement =
-        activeElements.length === 1
-          ? (activeElements[0] as HTMLElement)
-          : (activeElements[
-              Math.round(activeElements.length / 2)
-            ] as HTMLElement)
+      const activeElement = activeElements[
+        Math.floor(activeElements.length / 2)
+      ] as HTMLElement
 
       if (activeElement) {
-        // const documentScrollTop = document.documentElement.scrollTop
-        // const messagesRootOffsetTop = this.messagesContainer.offsetTop
-        // const isBehindFirstMessage = documentScrollTop > messagesRootOffsetTop
-        const activeElementOffset = activeElement.offsetTop
-        // const activeElementOffsetPersent = (activeElementOffset / innerWrapElement.clientHeight) * 100
-        // console.warn(activeElementOffset, innerWrapElement.clientHeight, maxOffsetPersent)
-        const scrollValue =
-          activeElementOffset > timelineHeight / 2 &&
-          !this.firstMessageIsVisible
-            ? this.element.clientHeight / 2 - activeElementOffset
-            : 0
+        // how far the list extends beyond the visible timeline area;
+        // zero when everything already fits, so nothing needs to move
+        const overflow = Math.max(
+          0,
+          innerWrapElement.scrollHeight - window.innerHeight
+        )
+        // the viewport centre, expressed relative to the timeline container
+        // so it can be compared against offsetTop
+        const viewportCentre =
+          window.innerHeight / 2 - this.element.getBoundingClientRect().top
+        // shift needed to bring the active month to that centre
+        const desired = viewportCentre - activeElement.offsetTop
+        // clamp the scroll value to the range [-overflow, 0] so that the list never scrolls past its own bounds
+        const scrollValue = Math.max(-overflow, Math.min(0, desired))
         innerWrapElement.style.transform = `translateY(${scrollValue}px)`
       }
     }

--- a/frontend/styles/components/request/message.scss
+++ b/frontend/styles/components/request/message.scss
@@ -5,7 +5,11 @@
   $avatar_size_mobile: 2.25rem; // 36px
   $avatar_right_margin_mobile: $spacer * 0.5;
   $avatar_right_margin_desktop: $spacer;
-  $message_body_margin_left_desktop: $avatar_size_desktop +
+  $expand_toggle_width: $spacer * 1.25;
+  $expand_toggle_right_margin_mobile: $avatar_right_margin_mobile * 0.5;
+  $expand_toggle_right_margin_desktop: $avatar_right_margin_desktop * 0.5;
+  $message_body_margin_left_desktop: $expand_toggle_width +
+    $expand_toggle_right_margin_desktop + $avatar_size_desktop +
     $avatar_right_margin_desktop + $spacer;
 
   display: flex;
@@ -89,6 +93,42 @@
   }
   &__meta-toggle {
     cursor: pointer;
+    padding: 0;
+    border: 0;
+    background: none;
+  }
+  &__meta-chevron,
+  &__expand-chevron {
+    display: inline-block;
+    transform: rotate(-90deg);
+    transition: transform 0.2s ease-in-out;
+  }
+  &__meta-toggle[aria-expanded='true'] &__meta-chevron,
+  &__expand-toggle[aria-expanded='true'] &__expand-chevron {
+    transform: rotate(0deg);
+  }
+  &__expand-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: $expand_toggle_width;
+    margin-right: $expand_toggle_right_margin_mobile;
+    padding: 0;
+    border: 0;
+    background: none;
+    color: var(--#{$prefix}tertiary-color);
+    cursor: pointer;
+    &:hover,
+    &:focus-visible {
+      color: var(--#{$prefix}body-color);
+    }
+    @include media-breakpoint-up(md) {
+      margin-right: $expand_toggle_right_margin_desktop;
+    }
+  }
+  &__expand-chevron {
+    font-size: 1.25em;
   }
   &__wrap {
     margin-left: $spacer;

--- a/frontend/styles/components/request/message.scss
+++ b/frontend/styles/components/request/message.scss
@@ -22,6 +22,7 @@
 
   &__head {
     cursor: pointer;
+    align-items: center;
   }
   &__avatar {
     flex: 0 0 $avatar_size_mobile;

--- a/frontend/styles/components/request/message.scss
+++ b/frontend/styles/components/request/message.scss
@@ -93,6 +93,9 @@
     display: none;
   }
   &__meta-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25em;
     cursor: pointer;
     padding: 0;
     border: 0;
@@ -100,7 +103,12 @@
   }
   &__meta-chevron,
   &__expand-chevron {
-    display: inline-block;
+    // a square box keeps the glyph centred as it rotates between states
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1em;
+    height: 1em;
     transform: rotate(-90deg);
     transition: transform 0.2s ease-in-out;
   }

--- a/frontend/styles/components/request/timeline.scss
+++ b/frontend/styles/components/request/timeline.scss
@@ -1,6 +1,6 @@
 .alpha-timeline {
   position: sticky;
-  top: 0;
+  top: 1em;
   left: 0;
   // max-height: 100vh;
   // height: 100vh;


### PR DESCRIPTION
- Tooltips on buttons (e.g. "Was bedeutet das?") are now reachable via keyboard and exposed to screen readers
- Collapsed messages now have a visually apparent toggle button, which also collapses the message again
- The "Details" control on messages is now a semantic <button> instead of a link, since it doesn't navigate to another page; it sets aria-expanded="true" when active so assistive tech is informed that the expanded content appeared
- The request-information timeline now has a heading, so it can be understood during non-visual use