### PR TITLE
♿️ Fix heading structure across templates

### DIFF
--- a/froide/account/templates/account/confirmed.html
+++ b/froide/account/templates/account/confirmed.html
@@ -15,7 +15,7 @@
         </div>
         <div class="row mt-5 justify-content-center">
             <div class="col-md-8 text-center">
-                <h2>{% trans "Your email address is now confirmed!" %}</h2>
+                <h1 class="h2">{% trans "Your email address is now confirmed!" %}</h1>
                 {% if foirequest %}
                     <p class="lead">
                         {% blocktrans trimmed with title=foirequest.title url=foirequest.get_absolute_url %}

--- a/froide/account/templates/account/includes/change_password_form.html
+++ b/froide/account/templates/account/includes/change_password_form.html
@@ -2,13 +2,13 @@
 {% load form_helper %}
 {% load account_tags %}
 <div id="change-password-now" class="card mb-3">
-    <h5 class="card-header">
+    <h2 class="h5 card-header">
         {% if form_title %}
             {{ form_title }}
         {% else %}
             {% trans "Change password" %}
         {% endif %}
-    </h5>
+    </h2>
     <div class="card-body">
         {% recentauthrequired %}
         <form action="{% url 'account-change_password' %}"

--- a/froide/account/templates/account/includes/recent_auth_required.html
+++ b/froide/account/templates/account/includes/recent_auth_required.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <div class="bg-body-secondary p-5">
-    <h6>{% translate "This section requires you to re-authenticate" %}</h6>
+    <p class="h6">{% translate "This section requires you to re-authenticate" %}</p>
     <a href="{% url 'account-reauth' %}?next={{ next | urlencode }}"
        class="btn btn-secondary">{% translate "Re-authenticate now" %}</a>
 </div>

--- a/froide/account/templates/account/login.html
+++ b/froide/account/templates/account/login.html
@@ -7,7 +7,7 @@
     <div class="row justify-content-center">
         <div class="col-lg-8 col-md-8">
             <div class="card mb-3">
-                <h5 class="card-header">{% blocktrans %}Log in{% endblocktrans %}</h5>
+                <h1 class="h5 card-header">{% blocktrans %}Log in{% endblocktrans %}</h1>
                 <div class="card-body">
                     <p class="visible-sm visible-xs">
                         <a href="{% url 'account-signup' %}">
@@ -29,7 +29,7 @@
                 </div>
             </div>
             <div class="card mb-3">
-                <h5 class="card-header">{% blocktrans %}In case you forgot your password...{% endblocktrans %}</h5>
+                <h2 class="h5 card-header">{% blocktrans %}In case you forgot your password...{% endblocktrans %}</h2>
                 <div class="card-body">
                     <p>{% blocktrans %}... we can send you a reset link to your email address.{% endblocktrans %}</p>
                     <form class="form-horizontal"

--- a/froide/account/templates/account/new_terms.html
+++ b/froide/account/templates/account/new_terms.html
@@ -4,7 +4,7 @@
 {% block body %}
     <div class="row justify-content-md-center mt-5">
         <div class="col-lg-8">
-            <h2>{% trans "Our Terms of Use have changed" %}</h2>
+            <h1 class="h2">{% trans "Our Terms of Use have changed" %}</h1>
             {% block terms_details %}{% endblock %}
             <form class="form-horizontal" method="post" action=".?next={{ next }}">
                 {% csrf_token %}

--- a/froide/account/templates/account/password_reset_confirm.html
+++ b/froide/account/templates/account/password_reset_confirm.html
@@ -9,7 +9,7 @@
     {% if validlink %}
         <div class="row justify-content-center mt-5">
             <div class="col-md-8">
-                <h2>{% trans 'Enter new password' %}</h2>
+                <h1 class="h2">{% trans 'Enter new password' %}</h1>
                 <p>{% trans "Please enter your new password twice so we can verify you typed it in correctly." %}</p>
                 <form action="" method="post">
                     {% csrf_token %}
@@ -21,7 +21,7 @@
             </div>
         </div>
     {% else %}
-        <h2>{% trans 'Password reset unsuccessful' %}</h2>
+        <h1 class="h2">{% trans 'Password reset unsuccessful' %}</h1>
         <p>
             {% trans "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset." %}
         </p>

--- a/froide/account/templates/account/profile.html
+++ b/froide/account/templates/account/profile.html
@@ -22,7 +22,7 @@
                     </div>
                 {% endif %}
                 <div class="col-8 col-md-12 mt-3">
-                    <h2>{{ object.get_full_name }}</h2>
+                    <h1 class="h2">{{ object.get_full_name }}</h1>
                     {% if object.organization_url and object.organization_name %}
                         <p>
                             <strong>
@@ -81,10 +81,10 @@
                     <div class="col-12">
                         <div class="card mb-3">
                             <div class="card-body">
-                                <h4 class="text-center">{% translate "Most followed requests" %}</h4>
+                                <h2 class="h4 text-center">{% translate "Most followed requests" %}</h2>
                                 <ul class="list-unstyled">
                                     {% for foirequest in top_followers %}
-                                        <li>{% include "foirequest/snippets/request_item.html" with object=foirequest %}</li>
+                                        <li>{% include "foirequest/snippets/request_item.html" with object=foirequest heading_tag="h3" %}</li>
                                     {% endfor %}
                                 </ul>
                             </div>
@@ -94,7 +94,7 @@
                 {% if top_publicbodies %}
                     <div class="col-12">
                         <div class="rounded-3 px-3 pt-3 pb-2 mb-3 bg-body-secondary">
-                            <h4 class="text-center">{% translate "Top requested public bodies" %}</h4>
+                            <h2 class="h4 text-center">{% translate "Top requested public bodies" %}</h2>
                             <ol class="lead">
                                 {% for pb in top_publicbodies %}
                                     <li>
@@ -112,12 +112,12 @@
             {% if foirequests %}
                 <div class="card mb-3">
                     <div class="card-header">
-                        <h4 class="my-1">{% translate "Last requests" %}</h4>
+                        <h2 class="h4 my-1">{% translate "Last requests" %}</h2>
                     </div>
                     <div class="card-body">
                         <ul class="list-unstyled">
                             {% for foirequest in foirequests %}
-                                <li>{% include "foirequest/snippets/request_item.html" with object=foirequest %}</li>
+                                <li>{% include "foirequest/snippets/request_item.html" with object=foirequest heading_tag="h3" %}</li>
                             {% endfor %}
                         </ul>
                         <a href="{% url 'foirequest-list' %}?user={{ object.username }}">
@@ -130,11 +130,11 @@
                 <hr />
                 <div class="card mb-3">
                     <div class="card-header">
-                        <h5>
+                        <h2 class="h5">
                             {% blocktrans trimmed with name=object.first_name %}
                                 {{ name }} has taken part in these campaigns
                             {% endblocktrans %}
-                        </h5>
+                        </h2>
                     </div>
                     <div class="card-body">
                         <ul class="list-unstyled">

--- a/froide/account/templates/account/reauth.html
+++ b/froide/account/templates/account/reauth.html
@@ -19,11 +19,13 @@
                     </div>
                 {% endif %}
                 <div class="card">
-                    <div class="card-header">{% translate "Please authenticate again with any of the methods below" %}</div>
+                    <h1 class="card-header heading-reset mb-0">
+                        {% translate "Please authenticate again with any of the methods below" %}
+                    </h1>
                     <ul class="list-group list-group-flush">
                         {% if "FIDO2" in mfa_methods %}
                             <li class="list-group-item">
-                                <h5>{% translate "Use hardware security key" %}</h5>
+                                <h2 class="h5">{% translate "Use hardware security key" %}</h2>
                                 <form data-fido2-auth="{{ mfa_data }}" method="POST" class="disable-submit">
                                     {% csrf_token %}
                                     {{ form.code.as_hidden }}
@@ -35,7 +37,7 @@
                         {% endif %}
                         {% if "TOTP" in mfa_methods %}
                             <li class="list-group-item">
-                                <h5>{% translate "Use your authenticator app" %}</h5>
+                                <h2 class="h5">{% translate "Use your authenticator app" %}</h2>
                                 <form method="post" class="disable-submit">
                                     {% csrf_token %}
                                     {% render_field form.code %}
@@ -47,7 +49,7 @@
                         {% endif %}
                         {% if request.user.has_usable_password %}
                             <li class="list-group-item">
-                                <h5>{% translate "Use your password" %}</h5>
+                                <h2 class="h5">{% translate "Use your password" %}</h2>
                                 <form method="post" class="disable-submit">
                                     {% csrf_token %}
                                     {% render_field form.password %}

--- a/froide/account/templates/account/settings.html
+++ b/froide/account/templates/account/settings.html
@@ -6,7 +6,7 @@
     {% trans "Account Settings" %}
 {% endblock title %}
 {% block settings_body %}
-    <h2>{% trans "Account Settings" %}</h2>
+    <h1 class="h2">{% trans "Account Settings" %}</h1>
     <dl id="general">
         <dt>{% blocktrans %}Your name:{% endblocktrans %}</dt>
         <dd>
@@ -50,7 +50,7 @@
         </dd>
     </dl>
     <div id="change-user-now" class="card mb-3 mt-5">
-        <h5 class="card-header">{% trans "Change details" %}</h5>
+        <h2 class="h5 card-header">{% trans "Change details" %}</h2>
         <div class="card-body">
             <form action="{% url 'account-change_user' %}"
                   method="post"
@@ -66,7 +66,7 @@
         </div>
     </div>
     <div id="settings" class="card mb-3 mt-5">
-        <h5 class="card-header">{% trans "Account settings" %}</h5>
+        <h2 class="h5 card-header">{% trans "Account settings" %}</h2>
         <div class="card-body">
             <form action="{% url 'account-change_settings' %}#settings" method="post">
                 {% csrf_token %}
@@ -81,7 +81,7 @@
     </div>
     {% if not request.user.private %}
         <div id="profile" class="card mb-3 mt-5">
-            <h5 class="card-header">{% trans "Public profile" %}</h5>
+            <h2 class="h5 card-header">{% trans "Public profile" %}</h2>
             <div class="card-body">
                 <p>
                     <a href="{{ request.user.get_absolute_url }}">{% translate "Your public profile" %}</a>
@@ -102,7 +102,7 @@
     {% endif %}
     {% include "account/includes/change_password_form.html" %}
     <div id="mfa" class="card mb-3">
-        <h5 class="card-header">{% translate "Setup two-factor login" %}</h5>
+        <h2 class="h5 card-header">{% translate "Setup two-factor login" %}</h2>
         <div class="card-body">
             {% recentauthrequired "mfa" %}
             {% if not request.user.has_usable_password %}
@@ -138,7 +138,7 @@
 {% block post_password %}
 {% endblock post_password %}
 <div id="proofs" class="card mb-3">
-    <h5 class="card-header">{% translate "Proofs" %}</h5>
+    <h2 class="h5 card-header">{% translate "Proofs" %}</h2>
     <div class="card-body">
         {% recentauthrequired "proofs" %}
         {% include "proof/proof_settings.html" %}
@@ -147,7 +147,7 @@
 </div>
 <hr />
 <div id="apps" class="card mb-3">
-    <h5 class="card-header">{% trans "External apps" %}</h5>
+    <h2 class="h5 card-header">{% trans "External apps" %}</h2>
     <div class="card-body">
         {% recentauthrequired "apps" %}
         <a href="{% url 'oauth2_provider:authorized-token-list' %}">
@@ -158,7 +158,7 @@
 </div>
 <hr />
 <div id="export" class="card mb-3">
-    <h5 class="card-header">{% trans "Export your data" %}</h5>
+    <h2 class="h5 card-header">{% trans "Export your data" %}</h2>
     <div class="card-body">
         {% recentauthrequired "export" %}
         <form action="{% url 'account-create_export' %}" method="post">
@@ -171,15 +171,15 @@
 </div>
 <hr />
 <div id="delete-account-section" class="card">
-    <h5 class="card-header">{% blocktrans %}Delete your account{% endblocktrans %}</h5>
+    <h2 class="h5 card-header">{% blocktrans %}Delete your account{% endblocktrans %}</h2>
     <div class="card-body">
         {% recentauthrequired "delete-account-section" %}
         <div class="alert alert-danger">
-            <h4>
+            <h3 class="h4">
                 <i class="fa fa-fire"></i>
                 {% trans "Danger: deleting your account cannot be undone." %}
                 <i class="fa fa-fire"></i>
-            </h4>
+            </h3>
             <form action="{% url 'account-delete_account' %}" method="post">
                 {% csrf_token %}
                 {% render_form user_delete_form %}
@@ -196,7 +196,7 @@
 </div>
 </div>
 <div id="developer" class="card mt-5">
-    <h5 class="card-header">{% blocktrans %}Developer{% endblocktrans %}</h5>
+    <h2 class="h5 card-header">{% blocktrans %}Developer{% endblocktrans %}</h2>
     <div class="card-body">
         {% if froide.api_activated %}
             {% recentauthrequired "developer" %}

--- a/froide/account/templates/account/signup.html
+++ b/froide/account/templates/account/signup.html
@@ -10,7 +10,7 @@
     <div class="row justify-content-center">
         <div class="col-lg-8 col-md-8">
             <div class="card mb-3 target-primary" id="signup">
-                <h5 class="card-header">{% blocktrans %}Create an account{% endblocktrans %}</h5>
+                <h1 class="h5 card-header">{% blocktrans %}Create an account{% endblocktrans %}</h1>
                 <div class="card-body">
                     <form class="form-horizontal"
                           method="post"

--- a/froide/account/templates/oauth2_provider/application_detail.html
+++ b/froide/account/templates/oauth2_provider/application_detail.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% block content %}
     <div class="block-center">
-        <h3 class="block-center-heading">{{ application.name }}</h3>
+        <h1 class="h3 block-center-heading">{{ application.name }}</h1>
         <ul class="unstyled">
             <li>
                 <p>

--- a/froide/account/templates/oauth2_provider/application_form.html
+++ b/froide/account/templates/oauth2_provider/application_form.html
@@ -7,11 +7,11 @@
               method="post"
               action="{% block app-form-action-url %}{% url 'oauth2_provider:update' application.id %}{% endblock app-form-action-url %}">
             {% csrf_token %}
-            <h3 class="block-center-heading">
+            <h1 class="h3 block-center-heading">
                 {% block app-form-title %}
                     {% trans "Edit application" %} {{ application.name }}
                 {% endblock app-form-title %}
-            </h3>
+            </h1>
             {% render_form form %}
             <div class="control-group">
                 <div class="controls">

--- a/froide/account/templates/oauth2_provider/authorize.html
+++ b/froide/account/templates/oauth2_provider/authorize.html
@@ -9,9 +9,9 @@
         <div class="col-md-8">
             {% if not error %}
                 <form id="authorizationForm" method="post">
-                    <h3 class="block-center-heading">
+                    <h1 class="h3 block-center-heading">
                         {% blocktrans with name=application.name %}Authorize the application '{{ name }}'?{% endblocktrans %}
-                    </h3>
+                    </h1>
                     <p>{% translate "The application has given the following description:" %}</p>
                     <blockquote class="simple-blockquote">
                         {{ application.description }}
@@ -42,7 +42,7 @@
                     </div>
                 </form>
             {% else %}
-                <h2>Error: {{ error.error }}</h2>
+                <h1 class="h2">Error: {{ error.error }}</h1>
                 <p>{{ error.description }}</p>
             {% endif %}
         </div>

--- a/froide/document/templates/document/result_item.html
+++ b/froide/document/templates/document/result_item.html
@@ -8,7 +8,8 @@
          alt="{% trans "Page" %} {{ object.number }} – {{ object.document.title }}" />
 </div>
 <div class="col ms-3 mb-3">
-    <h5 class="mt-0 mb-1">
+    {% with heading_tag=heading_tag|default:"h5" %}
+        <{{ heading_tag }} class="h5 mt-0 mb-1">
         <a href="{{ object.get_absolute_url }}">
             {% if has_query %}
                 {% trans "Page" %} {{ object.number }} – {{ object.document.title }}
@@ -16,7 +17,8 @@
                 {{ object.document.title }}
             {% endif %}
         </a>
-    </h5>
+        </{{ heading_tag }}>
+    {% endwith %}
     {% if object.document.foirequest %}
         <a href="{{ object.document.foirequest.get_absolute_url }}">
             <small class="badge text-bg-secondary">{{ object.document.foirequest.title|truncatechars:25 }}</small>

--- a/froide/document/templates/document/search.html
+++ b/froide/document/templates/document/search.html
@@ -38,10 +38,10 @@
 {% block sidebar_bottom %}
     <div class="card mb-3">
         <div class="card-body">
-            <h6>
+            <h2 class="h6">
                 <i class="fa fa-rss" aria-hidden="true"></i>
                 <a href="{% url 'document-search_feed' %}?{{ getvars }}">{% trans "RSS feed for this search" %}</a>
-            </h6>
+            </h2>
         </div>
     </div>
 {% endblock sidebar_bottom %}

--- a/froide/document/templates/document/upload.html
+++ b/froide/document/templates/document/upload.html
@@ -7,7 +7,7 @@
     {% include "header_reduced.html" %}
 {% endblock %}
 {% block app_body %}
-    <h3>{% blocktrans %}Upload documents{% endblocktrans %}</h3>
+    <h1 class="h3">{% blocktrans %}Upload documents{% endblocktrans %}</h1>
     <p class="lead">{% trans "You can upload large PDF documents or ZIP files of PDF documents here." %}</p>
     <form action="" method="post">
         {% csrf_token %}

--- a/froide/document/templates/filingcabinet/document_detail.html
+++ b/froide/document/templates/filingcabinet/document_detail.html
@@ -5,7 +5,7 @@
 {% load document_tags %}
 {% block document_top %}
     <div class="container mt-3 mb-5">
-        <h2 id="document-title">
+        <h1 class="h2" id="document-title">
             {{ object.title }}
             {% if object|can_write_document:request %}
                 <a href="#"
@@ -15,7 +15,7 @@
                     <span class="visually-hidden">{% trans "Edit title" %}</span>
                 </a>
             {% endif %}
-        </h2>
+        </h1>
         {% if object|can_write_document:request %}
             {% include 'filingcabinet/_set_title_form.html' with form_id='document-title-form' %}
             {% include 'filingcabinet/_set_description_form.html' with form_id='document-description-form' %}

--- a/froide/document/templates/filingcabinet/documentcollection_detail.html
+++ b/froide/document/templates/filingcabinet/documentcollection_detail.html
@@ -3,7 +3,7 @@
 {% load frontendbuild %}
 {% block documentcollection_top %}
     <div class="container mt-3 mb-5">
-        <h2>{{ object.title }}</h2>
+        <h1 class="h2">{{ object.title }}</h1>
         {% if object.description %}<p>{{ object.description|markdown }}</p>{% endif %}
     </div>
 {% endblock documentcollection_top %}

--- a/froide/foirequest/templates/foirequest/_assign_project_form.html
+++ b/froide/foirequest/templates/foirequest/_assign_project_form.html
@@ -3,7 +3,7 @@
 <form method="post"
       action="{{ submit_url }}"
       class="tight-margin d-flex flex-column w-100">
-    <h5 class="card-title">{{ legend }}</h5>
+    <h2 class="h5 card-title">{{ legend }}</h2>
     {% csrf_token %}{# needs to be below <h5> for `tight-margin` class to work #}
     <p>
         {% if object.project %}

--- a/froide/foirequest/templates/foirequest/account/list_drafts.html
+++ b/froide/foirequest/templates/foirequest/account/list_drafts.html
@@ -11,9 +11,9 @@
 {% block pre_table %}
     <div class="row">
         <div class="col-lg-8 mt-2">
-            <h2 class="mb-3">{% translate "Your draft requests" %}</h2>
+            <h1 class="h2 mb-3">{% translate "Your draft requests" %}</h1>
             {% trans "Search your draft requests" as search_title %}
-            <p>
+            <h2 class="heading-reset">
                 {% if view.query %}
                     {% blocktrans trimmed with query=view.query count request_count=page_obj.paginator.count %}
                         Your search for “{{ query }}” produced one search result.
@@ -27,7 +27,7 @@
                         You have {{ request_count }} request drafts.
                     {% endblocktrans %}
                 {% endif %}
-            </p>
+            </h2>
         </div>
     </div>
 {% endblock %}

--- a/froide/foirequest/templates/foirequest/account/list_following.html
+++ b/froide/foirequest/templates/foirequest/account/list_following.html
@@ -11,9 +11,9 @@
 {% block pre_table %}
     <div class="row">
         <div class="col-lg-8 mt-2">
-            <h2 class="mb-3">{% translate "Requests you follow" %}</h2>
+            <h1 class="h2 mb-3">{% translate "Requests you follow" %}</h1>
             {% trans "Search the requests you follow" as search_title %}
-            <p>
+            <h2 class="heading-reset">
                 {% if view.query %}
                     {% blocktrans trimmed with query=view.query count request_count=page_obj.paginator.count %}
                         You follow one request matching your search for “{{ query }}”.
@@ -27,7 +27,7 @@
                         You follow {{ request_count }} requests.
                     {% endblocktrans %}
                 {% endif %}
-            </p>
+            </h2>
         </div>
     </div>
 {% endblock %}
@@ -39,7 +39,7 @@
                title="{{ object.readable_status }}"></a>
         </td>
         <td>
-            {% include "foirequest/snippets/request_item_inner.html" %}
+            {% include "foirequest/snippets/request_item_inner.html" with heading_tag="h3" %}
             {% if object.status == "awaiting_response" %}
                 {% if object.due_date %}
                     <small>{% blocktrans with date=object.due_date|date:"DATE_FORMAT" %}Deadline: {{ date }}{% endblocktrans %}</small>

--- a/froide/foirequest/templates/foirequest/account/list_projects.html
+++ b/froide/foirequest/templates/foirequest/account/list_projects.html
@@ -11,9 +11,9 @@
 {% block pre_table %}
     <div class="row">
         <div class="col-lg-8 mt-2">
-            <h2 class="mb-3">{% translate "Your projects" %}</h2>
+            <h1 class="h2 mb-3">{% translate "Your projects" %}</h1>
             {% trans "Search your projects" as search_title %}
-            <p>
+            <h2 class="heading-reset">
                 {% if view.query %}
                     {% blocktrans trimmed with query=view.query count request_count=page_obj.paginator.count %}
                         Your search for “{{ query }}” produced one search result.
@@ -27,7 +27,7 @@
                         You have {{ request_count }} projects.
                     {% endblocktrans %}
                 {% endif %}
-            </p>
+            </h2>
         </div>
     </div>
 {% endblock %}

--- a/froide/foirequest/templates/foirequest/account/list_requests.html
+++ b/froide/foirequest/templates/foirequest/account/list_requests.html
@@ -15,10 +15,10 @@
 {% block pre_table %}
     <div class="row">
         <div class="col-12 mt-2">
-            <h2 class="mb-3">{% translate "Your requests" %}</h2>
+            <h1 class="h2 mb-3">{% translate "Your requests" %}</h1>
             {% url "account-requests" as search_url %}
             {% include "foirequest/_request_search.html" with search_url=search_url %}
-            <p>
+            <h2 class="heading-reset">
                 {% if is_filtered %}
                     {% blocktrans trimmed with request_count=page_obj.paginator.count|intcomma count counter=page_obj.paginator.count %}
                         Your search produced one search result.
@@ -32,7 +32,7 @@
                         You have {{ request_count }} requests.
                     {% endblocktrans %}
                 {% endif %}
-            </p>
+            </h2>
         </div>
     </div>
     <div class="row">
@@ -53,7 +53,7 @@
                        title="{{ object.readable_status }}"></a>
                 </td>
                 <td>
-                    {% include "foirequest/snippets/request_item_inner.html" %}
+                    {% include "foirequest/snippets/request_item_inner.html" with heading_tag="h3" %}
                     {% if object.status == "awaiting_user_confirmation" %}
                         <form class="d-inline"
                               action="{% url 'foirequest-confirm_request' slug=object.slug %}"

--- a/froide/foirequest/templates/foirequest/account/list_subscriptions.html
+++ b/froide/foirequest/templates/foirequest/account/list_subscriptions.html
@@ -12,7 +12,7 @@
 {% endblock %}
 {% block tab_content %}
     <div class="mt-2">
-        <h2 id="subscription-urls" class="mb-3">{% trans "Private Subscription URLs" %}</h2>
+        <h1 id="subscription-urls" class="h2 mb-3">{% trans "Private Subscription URLs" %}</h1>
         <p>{% trans "You can generate private URLs to subscribe to your requests in other applications." %}</p>
         <form action="{% url 'accesstoken-reset' %}#subscription-urls"
               method="POST">

--- a/froide/foirequest/templates/foirequest/attachment/manage.html
+++ b/froide/foirequest/templates/foirequest/attachment/manage.html
@@ -18,12 +18,12 @@
             <a href="{{ message.get_absolute_url }}"
                class="btn btn-outline-secondary">{% trans "Back" %}</a>
         </div>
-        <h2>{% trans "All attachments and options" %}</h2>
+        <h1 class="h2">{% trans "All attachments and options" %}</h1>
         {% translate "Here you can download and edit documents you have uploaded previously." %}
         {% csrf_token %}
         <attachment-manager id="attachment-manager" :message="{{ message_json }}" :config="{{ config_json }}" :user_is_staff="{{ user_is_staff }}">
         <div class="text-center">
-            <h4>{% trans "Attachments are loading..." %}</h4>
+            <p class="h4">{% trans "Attachments are loading..." %}</p>
             <div class="spinner-grow" style="width: 3rem; height: 3rem;" role="status">
                 <span class="visually-hidden">{% trans "Loading..." %}</span>
             </div>

--- a/froide/foirequest/templates/foirequest/body/actions/escalate.html
+++ b/froide/foirequest/templates/foirequest/body/actions/escalate.html
@@ -4,7 +4,7 @@
       method="post"
       action="{% url 'foirequest-escalation_message' slug=object.slug %}#escalate">
     {% csrf_token %}
-    <h4>{% blocktrans %}Ask for mediation for this request{% endblocktrans %}</h4>
+    <h2 class="h4">{% blocktrans %}Ask for mediation for this request{% endblocktrans %}</h2>
     <p>
         {% blocktrans trimmed %}
             If you think your request was not properly handled or it is delayed, you can ask for assistance.

--- a/froide/foirequest/templates/foirequest/body/actions/send_message.html
+++ b/froide/foirequest/templates/foirequest/body/actions/send_message.html
@@ -7,7 +7,7 @@
       action="{% url 'foirequest-send_message' slug=object.slug %}#write-message"
       enctype="multipart/form-data">
     {% csrf_token %}
-    <h4>{% blocktrans %}Send message to public body{% endblocktrans %}</h4>
+    <h2 class="h4">{% blocktrans %}Send message to public body{% endblocktrans %}</h2>
     {% if object.is_overdue %}
         <p>
             {% blocktrans %}Your request is <b>overdue</b>. You should send a reminder to the Public Body!{% endblocktrans %}

--- a/froide/foirequest/templates/foirequest/body/settings.html
+++ b/froide/foirequest/templates/foirequest/body/settings.html
@@ -31,7 +31,7 @@
             {% if object.response_messages %}
                 <div class="col-12 col-md-6 d-flex">
                     <div class="border border-2 border-gray-300 p-3 w-100">
-                        <h5>{% trans "Set Law" %}</h5>
+                        <h2 class="h5">{% trans "Set Law" %}</h2>
                         <form method="post"
                               class="disable-submit"
                               action="{% url 'foirequest-set_law' slug=object.slug %}">
@@ -48,7 +48,7 @@
             {% if not object.public %}
                 <div class="col-12 col-md-6 d-flex">
                     <div class="border border-2 border-gray-300 p-3 w-100">
-                        <h5>{% trans "Secret Short URL" %}</h5>
+                        <h2 class="h5">{% trans "Secret Short URL" %}</h2>
                         <p class="small help">{% trans "This URL gives read access to others." %}</p>
                         <p>
                             <input type="text"

--- a/froide/foirequest/templates/foirequest/header/header.html
+++ b/froide/foirequest/templates/foirequest/header/header.html
@@ -4,12 +4,12 @@
 <div class="container pt-2">
     {% if not object.public and object|can_read_foirequest_anonymous:request %}
         <div class="alert alert-warning">
-            <h4>{% trans "This request is not public!" %}</h4>
+            <h2 class="h4">{% trans "This request is not public!" %}</h2>
             <p>{% trans "You clicked a special URL that gave you access. Share the original link responsibly." %}</p>
         </div>
     {% elif object|can_read_foirequest_anonymous:request %}
         <div class="alert alert-warning">
-            <h4>{% trans "Special access" %}</h4>
+            <h2 class="h4">{% trans "Special access" %}</h2>
             <p>{% trans "You clicked a special URL that gave you access. Share the original link responsibly." %}</p>
         </div>
     {% endif %}
@@ -65,7 +65,7 @@
         <div class="col-md-6 col-lg-7 col-xl-8 mb-4">
             <div class="d-flex flex-column">
                 {# title #}
-                <h2 class="request-title">{{ object.title }}</h2>
+                <h1 class="h2 request-title">{{ object.title }}</h1>
                 {# recipient #}
                 <div class="mt-3 text-gray-500">
                     {% blocktrans %}Request to:{% endblocktrans %}
@@ -113,7 +113,7 @@
                 {% if object.summary or object|can_write_foirequest:request %}
                     {# result summary #}
                     <div class="mt-3">
-                        <h5>
+                        <h2 class="h5">
                             {% trans "Result of request" %}
                             {% if object|can_write_foirequest:request and object.summary %}
                                 <a href="#"
@@ -123,7 +123,7 @@
                                     <span class="visually-hidden">{% trans "Edit summary" %}</span>
                                 </a>
                             {% endif %}
-                        </h5>
+                        </h2>
                         <div id="request-summary">
                             {% if not object.summary and object|can_write_foirequest:request %}
                                 <p class="text-body-secondary smaller font-italic mb-0">

--- a/froide/foirequest/templates/foirequest/header/info-box.html
+++ b/froide/foirequest/templates/foirequest/header/info-box.html
@@ -14,7 +14,7 @@
     {# header (status, status icon) #}
     <div class="info-box__header d-flex flex-nowrap justify-content-between align-items-center">
         <div>
-            <h3 class="h5 info-box__title">{{ object.readable_status }}</h3>
+            <h2 class="h5 info-box__title">{{ object.readable_status }}</h2>
             {% if object.awaits_response and object.status_representation != 'awaiting_response' %}
                 <div class="info-box__subtitle">{% trans "Awaiting response" %}</div>
             {% endif %}

--- a/froide/foirequest/templates/foirequest/list.html
+++ b/froide/foirequest/templates/foirequest/list.html
@@ -48,7 +48,7 @@
 {% block search_results %}
     <ul class="list-unstyled">
         {% for object in object_list %}
-            <li>{% include "foirequest/snippets/request_item.html" %}</li>
+            <li>{% include "foirequest/snippets/request_item.html" with heading_tag="h3" %}</li>
         {% empty %}
             <li>
                 {% if filtered_objects %}
@@ -66,7 +66,7 @@
 {% block sidebar_bottom %}
     <div class="card mb-3">
         <div class="card-body">
-            <h6>{% blocktrans %}Feeds for these requests{% endblocktrans %}</h6>
+            <h2 class="h6">{% blocktrans %}Feeds for these requests{% endblocktrans %}</h2>
             <ul class="list-unstyled">
                 <li>
                     <a href="{% url 'foirequest-list_feed' %}?{{ getvars }}">

--- a/froide/foirequest/templates/foirequest/sent.html
+++ b/froide/foirequest/templates/foirequest/sent.html
@@ -18,13 +18,13 @@
         </div>
         <div class="row mt-5 mb-5 justify-content-center">
             <div class="col-md-8 text-center">
-                <h2 class="my-3">
+                <h1 class="h2 my-3">
                     {% if foiproject %}
                         {% trans "Your project was created!" %}
                     {% else %}
                         {% trans "Your request is being sent!" %}
                     {% endif %}
-                </h2>
+                </h1>
                 <div class="my-5">
                     {% if foirequest %}
                         <p class="mb-0">{% trans "We will send you an email when you receive a reply from the public body." %}</p>

--- a/froide/foirequest/templates/foirequest/snippets/request_item_inner.html
+++ b/froide/foirequest/templates/foirequest/snippets/request_item_inner.html
@@ -1,7 +1,8 @@
 {% load i18n %}
 {% load humanize %}
 <div>
-    <h5 class="mt-0 mb-1">
+    {% with heading_tag=heading_tag|default:"h5" %}
+        <{{ heading_tag }} class="h5 mt-0 mb-1">
         <a href="{{ object.url }}">{{ object.title }}</a>
         {% if object.follower_count %}
             <span class="badge text-bg-primary ms-2">
@@ -12,7 +13,8 @@
                 {% endblocktrans %}
             </span>
         {% endif %}
-    </h5>
+        </{{ heading_tag }}>
+    {% endwith %}
     <small>
         {% if object.project %}
             {% blocktrans with name=object.public_body.name url=object.public_body.get_absolute_url count=project.request_count|add:-1 urlp=object.project.get_absolute_url %}to <a href="{{ url }}">{{ name }}</a> and <a href="{{ urlp }}">{{ count }} other public bodies</a>{% endblocktrans %}

--- a/froide/helper/templates/helper/search/search_base.html
+++ b/froide/helper/templates/helper/search/search_base.html
@@ -7,10 +7,10 @@
     <div class="row">
         <div class="col-md-8 order-2">
             <div class="mb-3 mt-2">
-                <h2>
+                <h1 class="h2">
                     {% block search_title %}
                     {% endblock search_title %}
-                </h2>
+                </h1>
             </div>
             {% block search_form %}
                 <form action="{{ search_url }}"
@@ -32,7 +32,7 @@
             {% endblock search_form %}
             {% block search_results_label %}
                 <div class="mb-4 text-end">
-                    <p>
+                    <h2 class="heading-reset">
                         {% if filtered_objects %}
                             {% blocktrans trimmed with request_count=page_obj.paginator.formatted_count count counter=page_obj.paginator.count %}
                                 Your search produced one search result.
@@ -42,7 +42,7 @@
                         {% else %}
                             {% blocktrans with num=page_obj.paginator.formatted_count count counter=count %}One result{% plural %}{{ num }} results{% endblocktrans %}
                         {% endif %}
-                    </p>
+                    </h2>
                 </div>
             {% endblock search_results_label %}
             {% block search_results %}
@@ -50,7 +50,7 @@
                     {% for object in object_list %}
                         <li class="d-flex">
                             {% if object_template %}
-                                {% include object_template with object=object %}
+                                {% include object_template with object=object heading_tag="h3" %}
                             {% else %}
                                 <a href="{{ object.get_absolute_url }}">{{ object }}</a>
                             {% endif %}

--- a/froide/organization/templates/organization/organization_detail.html
+++ b/froide/organization/templates/organization/organization_detail.html
@@ -34,7 +34,7 @@
                     <h2 class="pb-3">{% trans "Last requests" %}</h2>
                     <ul class="list-unstyled row row-cols-md-2">
                         {% for foirequest in foirequests %}
-                            <li>{% include "foirequest/snippets/request_item.html" with object=foirequest %}</li>
+                            <li>{% include "foirequest/snippets/request_item.html" with object=foirequest heading_tag="h3" %}</li>
                         {% endfor %}
                     </ul>
                     <a href="{% url 'foirequest-list' %}?organization={{ object.slug }}">

--- a/froide/organization/templates/organization/organization_join.html
+++ b/froide/organization/templates/organization/organization_join.html
@@ -3,11 +3,11 @@
 {% block app_body %}
     <div class="row mb-3 mt-3">
         <div class="col-lg-8">
-            <h2>
+            <h1 class="h2">
                 {% blocktrans trimmed with name=object.organization.name %}
                     Organization “{{ name }}” has invited you
                 {% endblocktrans %}
-            </h2>
+            </h1>
             {% if request.user.email != object.email %}
                 <div class="alert alert-warning">
                     {% blocktrans trimmed with email=object.email account=request.user.email %}

--- a/froide/organization/templates/organization/organization_update_form.html
+++ b/froide/organization/templates/organization/organization_update_form.html
@@ -32,7 +32,7 @@
 {% block app_body %}
     <div class="row mb-3 mt-3">
         <div class="col-lg-8">
-            <h2>{% blocktrans with name=object.name %}Organization “{{ name }}”{% endblocktrans %}</h2>
+            <h1 class="h2">{% blocktrans with name=object.name %}Organization “{{ name }}”{% endblocktrans %}</h1>
         </div>
         <div class="col-lg-4">
             <a href="{% url 'organization-detail' slug=object.slug %}"
@@ -110,7 +110,7 @@
                 </table>
             </div>
             <div class="col-lg-4">
-                <h3>{% trans "Roles" %}</h3>
+                <h2 class="h3">{% trans "Roles" %}</h2>
                 <dl>
                     <dt>{% trans "Member" %}</dt>
                     <dd>
@@ -131,7 +131,7 @@
     {% if invite_form %}
         <div class="row">
             <div class="col-md-8">
-                <h4>{% trans "Add organization member" %}</h4>
+                <h2 class="h4">{% trans "Add organization member" %}</h2>
                 <form method="post"
                       action="{% url 'organization-invite' slug=object.slug %}">
                     {% csrf_token %}
@@ -146,7 +146,7 @@
     {% if form %}
         <div class="row mt-5">
             <div class="col-md-8">
-                <h4>{% trans "Edit organization" %}</h4>
+                <h2 class="h4">{% trans "Edit organization" %}</h2>
                 <form method="post"
                       action="{% url 'organization-update' slug=object.slug %}"
                       enctype="multipart/form-data">

--- a/froide/problem/templates/problem/moderation.html
+++ b/froide/problem/templates/problem/moderation.html
@@ -7,7 +7,7 @@
 {% endblock %}
 {% block body %}
     <div class="container-fluid">
-        <h2 class="mt-3">{% trans "Moderation" %}</h2>
+        <h1 class="h2 mt-3">{% trans "Moderation" %}</h1>
         <moderation-dashboard id="moderation-dashboard" :initial-publicbodies="{{ publicbodies_json }}" :initial-unclassified="{{ unclassified_json }}" :initial-unclassified-count="{{ unclassified_count }}" :initial-attachments="{{ attachments_json }}" :initial-attachments-count="{{ attachments_count }}" :config="{{ config_json }}">
         <div class="spinner-border" role="status"></div>
         </moderation-dashboard>

--- a/froide/publicbody/templates/publicbody/jurisdiction.html
+++ b/froide/publicbody/templates/publicbody/jurisdiction.html
@@ -19,7 +19,7 @@
             <div class="pb-5">
                 <div class="card">
                     <div class="card-body">
-                        <h5 class="card-title">{% trans "Which Public Bodies?" %}</h5>
+                        <h3 class="h5 card-title">{% trans "Which Public Bodies?" %}</h3>
                         {% url 'publicbody-list' jurisdiction=object.slug as pb_url %}
                         <p class="card-text">{% trans "All bodies that work on administrative tasks of this jurisdiction." %}</p>
                     </div>
@@ -31,7 +31,7 @@
                 </div>
                 <div class="card">
                     <div class="card-body">
-                        <h5 class="card-title">{% trans "What Information?" %}</h5>
+                        <h3 class="h5 card-title">{% trans "What Information?" %}</h3>
                         <p class="card-text">
                             {% trans "Contracts, memos, reports and other documents of the administration: you have the right to know." %}
                         </p>
@@ -43,7 +43,7 @@
                 </div>
                 <div class="card">
                     <div class="card-body">
-                        <h5 class="card-title">{% trans "What right?" %}</h5>
+                        <h3 class="h5 card-title">{% trans "What right?" %}</h3>
                         <p class="card-text">
                             {% blocktrans with name=object.name %}The freedom of information law in {{ name }} allows you access to administrative information. {% endblocktrans %}
                         </p>
@@ -63,7 +63,7 @@
                         {% with page_url="/"|add:object.slug|add:"/text/" %}
                             {% get_flatpages page_url as content_page %}
                             {% if content_page %}
-                                <h3>{{ content_page.0.title }}</h3>
+                                <h2 class="h3">{{ content_page.0.title }}</h2>
                                 {{ content_page.0.content|safe }}
                             {% endif %}
                         {% endwith %}
@@ -71,18 +71,18 @@
                 </div>
                 <div class="col-lg-4 col-md-4">
                     {% block jurisdiction_sidebar %}
-                        <h3>
+                        <h2 class="h3">
                             {% block jurisdiction_sidebar_header %}
                                 {% blocktrans with name=SITE_NAME %}Facts about {{ name }}{% endblocktrans %}
                             {% endblock %}
-                        </h3>
+                        </h2>
                         {% block jurisdiction_sidebar_content %}{% endblock %}
                         {% block jurisdiction_sidebar_laws %}
-                            <h3>
+                            <h2 class="h3">
                                 {% block jurisdiction_sidebar_laws_header %}
                                     {% blocktrans with name=object.name %}Information laws in {{ name }}{% endblocktrans %}
                                 {% endblock %}
-                            </h3>
+                            </h2>
                             {% for law in laws %}
                                 {% block jurisdiction_sidebar_laws_law %}
                                     <p>
@@ -97,14 +97,14 @@
                             {% endfor %}
                         {% endblock %}
                         {% block jurisdiction_sidebar_requests %}
-                            <h3>
+                            <h2 class="h3">
                                 {% block jurisdiction_sidebar_requests_header %}
                                     {% blocktrans with name=object.name %}Requests in {{ name }}{% endblocktrans %}
                                 {% endblock %}
-                            </h3>
+                            </h2>
                             <ul class="list-unstyled">
                                 {% for foirequest in foirequests %}
-                                    <li>{% include "foirequest/snippets/request_item.html" with object=foirequest %}</li>
+                                    <li>{% include "foirequest/snippets/request_item.html" with object=foirequest heading_tag="h3" %}</li>
                                 {% endfor %}
                             </ul>
                         {% endblock %}

--- a/froide/publicbody/templates/publicbody/show.html
+++ b/froide/publicbody/templates/publicbody/show.html
@@ -26,7 +26,7 @@
 {% endblock %}
 {% block app_body %}
     <div itemscope itemtype="http://schema.org/Organization">
-        <h2 itemprop="name">{{ object.name }}</h2>
+        <h1 class="h2" itemprop="name">{{ object.name }}</h1>
         {% if object.email and object.confirmed %}
             <p>
                 <a class="btn btn-primary"
@@ -162,7 +162,7 @@
             <div class="col-lg-8 col-md-8">
                 {% if not object.confirmed %}
                     <div class="alert alert-warning">
-                        <h3>{% trans "Proposal" %}</h3>
+                        <h2 class="h3">{% trans "Proposal" %}</h2>
                         {% if object.created_by == request.user %}
                             <p>{% trans "You have proposed this public body, but it has not been confirmed yet." %}</p>
                         {% else %}
@@ -173,13 +173,13 @@
                 {% if object.request_note %}
                     <div class="panel panel-info">
                         <div class="card-header">
-                            <h3 class="card-title">{% trans "Special note" %}</h3>
+                            <h2 class="h3 card-title">{% trans "Special note" %}</h2>
                         </div>
                         <div class="card-body">{{ object.request_note_html|safe }}</div>
                     </div>
                 {% endif %}
                 {% if foirequest_count %}
-                    <h3>{% trans "Summary of Results" %}</h3>
+                    <h2 class="h3">{% trans "Summary of Results" %}</h2>
                     <table class="table">
                         {% for res in resolutions %}
                             <tr>
@@ -197,12 +197,12 @@
                             </tr>
                         {% endfor %}
                     </table>
-                    <h3>
+                    <h2 class="h3">
                         {% blocktrans count count=foirequest_count %}One request to this public body{% plural %}{{ count }} requests to this public body{% endblocktrans %}
-                    </h3>
+                    </h2>
                     <ul class="list-unstyled">
                         {% for object in foirequests %}
-                            <li>{% include "foirequest/snippets/request_item.html" %}</li>
+                            <li>{% include "foirequest/snippets/request_item.html" with heading_tag="h3" %}</li>
                         {% endfor %}
                     </ul>
                     <p>

--- a/froide/publicbody/templates/publicbody/show_foilaw.html
+++ b/froide/publicbody/templates/publicbody/show_foilaw.html
@@ -3,7 +3,7 @@
 {% load markup %}
 {% block title %}{{ object.name }} - {{ SITE_NAME }}{% endblock %}
 {% block app_body %}
-    <h2>{{ object.name }}</h2>
+    <h1 class="h2">{{ object.name }}</h1>
     <div class="row mt-4">
         <div class="col-md-3">
             <dl class="my-0">

--- a/froide/publicbody/templates/publicbody/snippets/publicbody_item.html
+++ b/froide/publicbody/templates/publicbody/snippets/publicbody_item.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 <div class="flex-grow-1 ms-3 mb-3">
-    <h5 class="mt-0 mb-1">
+    {% with heading_tag=heading_tag|default:"h5" %}
+        <{{ heading_tag }} class="h5 mt-0 mb-1">
         <a href="{{ object.get_absolute_url }}">{{ object.name }}</a>
         <br />
         <small>
@@ -11,5 +12,6 @@
                 {% trans "no requests yet" %}
             {% endif %}
         </small>
-    </h5>
+        </{{ heading_tag }}>
+    {% endwith %}
 </div>

--- a/froide/team/templates/team/_assign_team_form.html
+++ b/froide/team/templates/team/_assign_team_form.html
@@ -3,7 +3,7 @@
 <form method="post"
       action="{{ submit_url }}"
       class="tight-margin d-flex flex-column w-100">
-    <h5>{{ legend }}</h5>
+    <h2 class="h5">{{ legend }}</h2>
     {% csrf_token %}{# needs to be below <h5> for `tight-margin` class to work #}
     <p>
         {% if object.team %}

--- a/froide/team/templates/team/team_detail.html
+++ b/froide/team/templates/team/team_detail.html
@@ -7,7 +7,7 @@
 {% block app_body %}
     <div class="row mb-3 mt-3">
         <div class="col-lg-8">
-            <h2>{% blocktrans with name=object.name %}Team “{{ name }}”{% endblocktrans %}</h2>
+            <h1 class="h2">{% blocktrans with name=object.name %}Team “{{ name }}”{% endblocktrans %}</h1>
         </div>
         <div class="col-lg-4">
             <a href="{% url 'team-list' %}" class="btn btn-secondary float-end">
@@ -82,7 +82,7 @@
                 </table>
             </div>
             <div class="col-lg-4">
-                <h3>{% trans "Roles" %}</h3>
+                <h2 class="h3">{% trans "Roles" %}</h2>
                 <dl>
                     <dt>{% trans "Viewer" %}</dt>
                     <dd>
@@ -109,7 +109,7 @@
     {% if form %}
         <div class="row mt-5">
             <div class="col-md-8">
-                <h4>{% trans "Add team member" %}</h4>
+                <h2 class="h4">{% trans "Add team member" %}</h2>
                 <form method="post" action="{% url 'team-invite' pk=object.pk %}">
                     {% csrf_token %}
                     {% render_form form %}
@@ -122,7 +122,7 @@
     {% endif %}
     <div class="row mt-5">
         <div class="col-md-12">
-            <h3>{% trans "Requests accessible to this team" %}</h3>
+            <h2 class="h3">{% trans "Requests accessible to this team" %}</h2>
             <table class="table table-responsive table-condensed">
                 <thead>
                     <th>{% blocktrans %}Title{% endblocktrans %}</th>
@@ -153,7 +153,7 @@
     </div>
     <div class="row mt-5">
         <div class="col-md-12">
-            <h3>{% trans "Team projects" %}</h3>
+            <h2 class="h3">{% trans "Team projects" %}</h2>
             <table class="table table-responsive">
                 <thead>
                     <th>{% blocktrans %}Title{% endblocktrans %}</th>
@@ -177,7 +177,7 @@
     {% if user_member.is_owner %}
         <div class="row mt-5">
             <div class="col-md-8">
-                <h3>{% trans "Delete team" %}</h3>
+                <h2 class="h3">{% trans "Delete team" %}</h2>
                 <p>
                     {% trans "Deleting the team will remove access of team members to all requests and projects they did not create." %}
                 </p>

--- a/froide/team/templates/team/team_join.html
+++ b/froide/team/templates/team/team_join.html
@@ -3,11 +3,11 @@
 {% block app_body %}
     <div class="row mb-3 mt-3">
         <div class="col-lg-8">
-            <h2>
+            <h1 class="h2">
                 {% blocktrans trimmed with name=object.team.name %}
                     Team “{{ name }}” has invited you
                 {% endblocktrans %}
-            </h2>
+            </h1>
             {% if request.user.email != object.email %}
                 <div class="alert alert-warning">
                     {% blocktrans trimmed with email=object.email account=request.user.email %}

--- a/froide/team/templates/team/team_list.html
+++ b/froide/team/templates/team/team_list.html
@@ -4,7 +4,7 @@
 {% block app_body %}
     <div class="row mb-3 mt-3">
         <div class="col-lg-8">
-            <h2>{% trans "Your Teams" %}</h2>
+            <h1 class="h2">{% trans "Your Teams" %}</h1>
         </div>
     </div>
     <div class="row">

--- a/froide/templates/footer.html
+++ b/froide/templates/footer.html
@@ -8,7 +8,7 @@
             {% endblock footer_above %}
             <div class="row">
                 <div class="col-md-4">
-                    <h3>{{ SITE_NAME }}</h3>
+                    <h2 class="h3">{{ SITE_NAME }}</h2>
                 </div>
             </div>
             <div class="row">

--- a/froide/templates/index.html
+++ b/froide/templates/index.html
@@ -12,7 +12,7 @@
             <div class="row">
                 <div class="col-lg-6 col-md-6">
                     {% block index_sub_left %}
-                        <h3>{% blocktrans %}What is Freedom of Information?{% endblocktrans %}</h3>
+                        <h2 class="h3">{% blocktrans %}What is Freedom of Information?{% endblocktrans %}</h2>
                         <p>
                             {% blocktrans %}Every citizen has the right under the Freedom of Information Laws to ask for and receive access to information from Public Bodies concerning public affairs.{% endblocktrans %}
                             <br />
@@ -24,7 +24,7 @@
                 </div>
                 <div class="col-lg-6 col-md-6">
                     {% block index_sub_right %}
-                        <h3>{% blocktrans %}What does this site do?{% endblocktrans %}</h3>
+                        <h2 class="h3">{% blocktrans %}What does this site do?{% endblocktrans %}</h2>
                         <p>
                             {% blocktrans %}This site publishes Freedom of Information requests and replies so that others don't have to ask for the same information and replies can be scrutinized by the public.{% endblocktrans %}
                             <br />
@@ -38,20 +38,20 @@
             <div class="row">
                 <div class="col-lg-6 col-md-6">
                     {% if successful_foi_requests %}
-                        <h3>{% blocktrans %}Successful Requests{% endblocktrans %}</h3>
+                        <h2 class="h3">{% blocktrans %}Successful Requests{% endblocktrans %}</h2>
                         <ul class="list-unstyled">
                             {% for object in successful_foi_requests %}
-                                <li>{% include "foirequest/snippets/request_item.html" %}</li>
+                                <li>{% include "foirequest/snippets/request_item.html" with heading_tag="h3" %}</li>
                             {% endfor %}
                         </ul>
                     {% endif %}
                 </div>
                 <div class="col-lg-6 col-md-6">
                     {% if unsuccessful_foi_requests %}
-                        <h3>{% blocktrans %}Unsuccessful Requests{% endblocktrans %}</h3>
+                        <h2 class="h3">{% blocktrans %}Unsuccessful Requests{% endblocktrans %}</h2>
                         <ul class="list-unstyled">
                             {% for object in unsuccessful_foi_requests %}
-                                <li>{% include "foirequest/snippets/request_item.html" %}</li>
+                                <li>{% include "foirequest/snippets/request_item.html" with heading_tag="h3" %}</li>
                             {% endfor %}
                         </ul>
                     {% endif %}

--- a/froide/templates/snippets/homepage_hero.html
+++ b/froide/templates/snippets/homepage_hero.html
@@ -6,9 +6,9 @@
             {% block first_index_row %}
                 <div class="col-lg-6 col-md-6">
                     {% block first_index_row_search %}
-                        <h2>
+                        <h1 class="h2">
                             {% block site_name %}{{ SITE_NAME }}{% endblock %}
-                        </h2>
+                        </h1>
                         {% block site_description %}
                             <p class="lead">
                                 {% blocktrans %}This site publishes Freedom of Information requests and helps you to make your own!{% endblocktrans %}
@@ -52,11 +52,11 @@
                         <div id="main-foirequests" class="well">
                             {% if featured %}
                                 <div>
-                                    <h3>
+                                    <h2 class="h3">
                                         <small>{% trans "Featured Request" %}</small>
                                         <br />
                                         {{ featured.title }}
-                                    </h3>
+                                    </h2>
                                     <p>{{ featured.text|truncatewords:55|linebreaksbr }}</p>
                                     <p>
                                         {% if featured.url %}

--- a/froide/tests/live/snapshots/test_a11y/test_a11y_chromium_account_login.txt
+++ b/froide/tests/live/snapshots/test_a11y/test_a11y_chromium_account_login.txt
@@ -1,2 +1,1 @@
 violations:color-contrast
-violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_a11y/test_a11y_chromium_account_signup.txt
+++ b/froide/tests/live/snapshots/test_a11y/test_a11y_chromium_account_signup.txt
@@ -1,2 +1,1 @@
 violations:color-contrast
-violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_a11y/test_a11y_chromium_index.txt
+++ b/froide/tests/live/snapshots/test_a11y/test_a11y_chromium_index.txt
@@ -1,3 +1,2 @@
 violations:color-contrast
 violations:link-in-text-block
-violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_a11y/test_a11y_foirequest_list_search_options_chromium.txt
+++ b/froide/tests/live/snapshots/test_a11y/test_a11y_foirequest_list_search_options_chromium.txt
@@ -1,5 +1,3 @@
 incomplete:color-contrast
 violations:color-contrast
-violations:heading-order
-violations:page-has-heading-one
 violations:select-name

--- a/froide/tests/live/snapshots/test_a11y/test_a11y_logged_in_chromium_account_confirmed.txt
+++ b/froide/tests/live/snapshots/test_a11y/test_a11y_logged_in_chromium_account_confirmed.txt
@@ -1,2 +1,0 @@
-violations:heading-order
-violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_a11y/test_a11y_logged_in_chromium_account_settings.txt
+++ b/froide/tests/live/snapshots/test_a11y/test_a11y_logged_in_chromium_account_settings.txt
@@ -1,5 +1,3 @@
 incomplete:color-contrast
 violations:color-contrast
-violations:heading-order
 violations:label
-violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_a11y/test_a11y_staff_chromium_document_upload.txt
+++ b/froide/tests/live/snapshots/test_a11y/test_a11y_staff_chromium_document_upload.txt
@@ -2,4 +2,3 @@ incomplete:aria-prohibited-attr
 incomplete:aria-required-children
 incomplete:color-contrast
 violations:color-contrast
-violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_request/test_make_logged_in_request_chromium.txt
+++ b/froide/tests/live/snapshots/test_request/test_make_logged_in_request_chromium.txt
@@ -1,3 +1,2 @@
 incomplete:aria-prohibited-attr
 violations:color-contrast
-violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_chromium_account_confirmed.txt
+++ b/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_chromium_account_confirmed.txt
@@ -1,3 +1,1 @@
-violations:heading-order
 violations:link-in-text-block
-violations:page-has-heading-one

--- a/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_chromium_account_new.txt
+++ b/froide/tests/live/snapshots/test_request/test_make_not_logged_in_request_chromium_account_new.txt
@@ -1,1 +1,0 @@
-violations:heading-order

--- a/froide/tests/live/snapshots/test_request/test_set_status_chromium_unset_successful_detail.txt
+++ b/froide/tests/live/snapshots/test_request/test_set_status_chromium_unset_successful_detail.txt
@@ -4,6 +4,4 @@ incomplete:link-in-text-block
 violations:aria-required-children
 violations:aria-required-parent
 violations:color-contrast
-violations:heading-order
 violations:listitem
-violations:page-has-heading-one

--- a/froide/tests/live/test_request.py
+++ b/froide/tests/live/test_request.py
@@ -80,7 +80,7 @@ async def test_make_not_logged_in_request(
     await page.goto("%s%s" % (live_server.url, activate_url))
     account_confirmed = reverse("account-confirmed")
     assert account_confirmed in page.url
-    await expect(page.locator("xpath=//h2")).to_have_text(
+    await expect(page.locator("xpath=//h1")).to_have_text(
         "Your email address is now confirmed!"
     )
     req = FoiRequest.objects.get(user=new_user)

--- a/frontend/javascript/components/moderation/moderation-dashboard.vue
+++ b/frontend/javascript/components/moderation/moderation-dashboard.vue
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-auto col-lg-2 order-lg-2">
       <div class="sidebar">
-        <h5>{{ i18n.activeModerators }}</h5>
+        <h2 class="h5">{{ i18n.activeModerators }}</h2>
         <ul>
           <li v-for="moderator in namedModerators" :key="moderator.id">
             {{ moderator.name }}

--- a/frontend/styles/components/footer.scss
+++ b/frontend/styles/components/footer.scss
@@ -13,7 +13,7 @@ $footer-color-hover: $gray-100;
     padding-top: $spacer;
   }
 
-  h6 {
+  :where(h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6) {
     color: $gray-100;
     margin-bottom: $spacer * 0.5;
     margin-top: $spacer;

--- a/frontend/styles/components/type.scss
+++ b/frontend/styles/components/type.scss
@@ -19,6 +19,18 @@ h3 {
   hyphens: manual;
 }
 
+// Make a heading look and space like a regular paragraph.
+.heading-reset {
+  font-size: $font-size-base;
+  font-weight: $font-weight-normal;
+  margin-bottom: $paragraph-margin-bottom;
+  hyphens: auto;
+
+  &:not(:first-child) {
+    margin-top: 0;
+  }
+}
+
 .no-hyphens {
   hyphens: none;
 }


### PR DESCRIPTION
Fixes the heading structure across templates, changing the document outline with as little visual change as possible:
  - every page gets exactly one `<h1>`,
  - heading levels no longer skip steps,
  - text that is not a section label is no longer a heading.
                                                                
  Visual appearance is preserved with Bootstrap's heading classes (e.g. `<h1 class="h2">`). Where an element is needed in the outline but shouldn't look like a heading, it becomes a heading with the new `.heading-reset` class, which renders it like regular paragraph text.
  
Other changes:
  - The list item partials (`request_item_inner.html`, `publicbody_item.html`, `document/result_item.html`) accept a `heading_tag` parameter, since they are included at different outline depths. It defaults to `<h5>`, so existing includes in downstream themes are unchanged.
  - The footer styles apply to all heading levels and `.h1`–`.h6` classes instead of just `<h6>`, so any heading size can be used in the footer.
  
Most pages can be reviewed using the fragdenstaat_de dev setup. The exceptions are the index page and the footer, which are specific to froide and have to be checked in a standalone froide setup.